### PR TITLE
Migrate from Quarto to mdBook with link checking and ASCII diagrams

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Build and Deploy
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
@@ -17,8 +19,36 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install tools
+        run: |
+          cargo install just
+          just setup
+
+      - name: Lint
+        run: just lint
+
   build:
     runs-on: ubuntu-latest
+    needs: lint
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,37 +56,45 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y chromium
-          sudo ln -sf /usr/bin/chromium /usr/bin/chromium-browser
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Setup Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
         with:
-          tinytex: true
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Setup Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install dependencies
+        run: |
+          # Install pandoc and LaTeX for PDF generation
+          sudo apt-get update
+          sudo apt-get install -y pandoc texlive-latex-recommended texlive-fonts-recommended texlive-luatex fonts-dejavu
+          # Install Rust tools
+          cargo install just
+          just setup
 
-      - name: Install tools
-        run: brew install just vale node
-
-      - name: Build site and PDF
+      - name: Build documentation
         run: just build
+
+      - name: Upload release PDF
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./book/pandoc/pdf/adr-guide.pdf
+          asset_name: adr-guide.pdf
+          asset_content_type: application/pdf
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./_site
-
-      - name: Upload PDF artifact
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v4
-        with:
-          name: architecture-decision-records-pdf
-          path: ./_site/architecture-decision-records.pdf
+          path: ./book
 
   deploy:
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
@@ -69,21 +107,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-
-  release:
-    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Download PDF artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: architecture-decision-records-pdf
-          path: ./pdfs
-
-      - name: Attach PDF to release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: ./pdfs/architecture-decision-records.pdf
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
-*.log
+*.logbook/

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,13 @@
+# rumdl configuration for ADR project
+[global]
+exclude = ["SUMMARY.md"]
+
+# Stricter linting - only disable what's absolutely necessary
+disabled-rules = []
+
+# Configure line length rule
+[MD013]
+line-length = 120
+code-blocks = false  # Don't check line length in code blocks (ASCII diagrams)
+
+# Allow multiple top-level headings only in SUMMARY.md (handled by exclude)

--- a/AGENT.md
+++ b/AGENT.md
@@ -4,115 +4,26 @@
 
 | Command | Purpose |
 |---------|---------|
-| `just next-number` | Get next ADR number |
-| `just validate` | Check format and prose quality |
+| `./scripts/setup.sh` | Automated setup (first time) |  
+| `just setup` | Install tools (rumdl, mdbook, linkcheck) |
+| `just lint` | Lint, format check, SUMMARY.md check, and validate links |
 | `just serve` | Preview website (port 8080) |
-| `just build` | Generate website/PDF |
+| `just build` | Generate website (includes link checking) |
 | `just clean` | Remove generated files |
-| `just update-chapters` | Update book chapters from files |
+| `just next-number` | Get next ADR number |
 
 ## Quick Start
 
 1. **Open in Codespaces** - Automatic setup with all tools
 2. **Get ADR number** - `just next-number`
-3. **Create file** - Use pattern `###-short-name.qmd` in correct directory
-4. **Write ADR** - Follow template structure
-5. **Validate** - `just validate` (fix any issues)
-6. **Preview** - `just serve` to check locally
-7. **Submit PR** - No need to update index files
+3. **Create file** - Use pattern `###-short-name.md` in correct directory
+4. **Follow workflow** - See [CONTRIBUTING.md](CONTRIBUTING.md) for complete workflow, templates, and writing guidelines
 
-## Content Organization
+## PDF Generation
 
-### ADRs (Numbered decisions)
-
-```text
-development/          # API standards, CI/CD, releases
-operations/           # Infrastructure, logging, config  
-security/             # Isolation, secrets, AI governance
-```
-
-### Reference Architectures (Project templates)
-
-```text
-reference-architectures/  # Combine existing ADRs for specific use cases
-```
-
-**Key**: Numbers are globally unique across directories. Gaps (006, 008) are from removed drafts.
-
-## Template
-
-```markdown
----
-title: "ADR ###: Decision Title"
-date: YYYY-MM-DD
-status: Proposed
-tags: [category, tech]
----
-
-**Status:** {{< meta status >}} | **Date:** {{< meta date >}}
-
-## Context
-Problem statement and background
-
-## Decision
-What we decided and implementation approach
-
-## Consequences
-Trade-offs, risks, and benefits
-```
-
-**Important**: Tags should NOT be prefixed with # to avoid YAML parsing errors  
-**Numbering**: Use `just next-number` to get next sequential ADR number (gaps from removed drafts are normal)
-
-## Writing Guidelines
-
-- **Frontmatter Tags** - Do NOT prefix tags with # to avoid YAML parsing errors
-  - Use `tags: [category, tech]` not `tags: [#category, #tech]`
-
-- **Avoid Extended Characters** - Use ASCII characters only to prevent PDF font rendering issues
-  - Use `"quotes"` not `"smart quotes"`
-  - Use `--` not em dashes `—`
-  - Use `[x]` or `YES` instead of unicode symbols like `✅`
-  - Use standard apostrophes `'` not curved `'`
-
-- **Terminology Standards** - Use consistent terminology for broad applicability
-  - Use "jurisdiction compliance/requirements" instead of "government compliance/requirements"
-  - Use "organisational" instead of "government" when referring to general use cases
-  - Reference specific jurisdiction standards in links where appropriate
-
-- **Australian English** - Use Australian English spelling and terminology
-  - Use "optimisation" not "optimization"
-  - Use "colour" not "color"
-  - Use "centre" not "center"
-  - Use "organisation" not "organization"
-
-- **Writing Objectives** - Prioritise simplicity, conciseness, and usability
-  - Keep ADRs lightweight and focused on essential decisions
-  - Use bullet points and numbered lists for easy scanning
-  - Link to existing ADRs rather than repeating detailed guidance
-  - Focus on practical implementation steps over comprehensive coverage
-
-## ADR Philosophy
-
-**Focus on Foundational Decisions Only:**
-
-- ADRs address decisions with high cost to change mid/late project
-- Cover architectural patterns, technology standards, and security frameworks
-- Avoid detailed implementation guidance that can be handled in documentation
-
-**Reference Architecture Approach:**
-
-- Link to existing foundational ADRs (9-11 steps maximum)
-- Use "Implementation Details" section for specifics that don't need ADRs
-- Consolidate related concerns into single comprehensive ADRs
-- Prioritise decisions that affect multiple teams or long-term maintainability
-
-## Automated Features
-
-- **Chapter ordering** - Files sorted numerically by ADR number
-- **Executive summaries** - Index pages automatically updated by build
-- **Acronym checking** - Vale ensures first-use definitions
-- **Prose quality** - Write-good catches wordy/passive constructions
+- **Build** - `just build` creates both website and PDF at `book/pandoc/pdf/adr-guide.pdf`
+- **Live PDF** - Available at [book/pandoc/pdf/adr-guide.pdf](book/pandoc/pdf/adr-guide.pdf)
+- **Format** - A4 ISO standard with optimized fonts for ASCII diagrams
 
 ## Troubleshooting
 
@@ -124,27 +35,17 @@ Trade-offs, risks, and benefits
 
 **Validation Issues:**
 
-- Check frontmatter format matches template exactly
-- Run `just validate` to check all issues
-- Use `just clean` then `just build` if preview issues occur
+- Run `just lint` to check all issues
+- Use `just clean` then `just serve` if preview issues occur
 
 ## Automated Workflows
 
 - **Website deployment** - Automatically builds and deploys to GitHub Pages on push to `main`
-- **PDF generation** - Automatically creates and attaches PDFs to GitHub releases
+- **PDF generation** - Automatically creates and attaches PDFs to GitHub releases  
 - **Chapter ordering** - Files sorted numerically by ADR number
-- **Index updates** - Executive summaries automatically generated
-- **Auto-add directories** - `just update-chapters` automatically adds any top-level directory containing `.qmd` files to book structure
-- **README index** - `just update-chapters` automatically generates ADR index in README.md for GitHub navigation
 
-## Quarto Project Notes
+## mdBook Project Notes
 
-- **Diagram Support** - Use Mermaid diagrams with ````{mermaid}` code blocks (full quarto support with captions)
-- **Reference Architectures** - Located in root directory, use simple flat structure
-- **Book Format** - Project uses quarto book format, chapters defined in `_quarto.yml`
-
-## Maintainer Tasks
-
-1. Review proposed ADRs (change status to Accepted)
-2. Create releases through GitHub (PDFs automatically attached)
-3. Monitor GitHub Actions for build status
+- **Book Format** - Project uses mdBook, navigation defined in `SUMMARY.md`
+- **Manual Updates** - Add new ADR files to `SUMMARY.md` for navigation (required)
+- **Diagram Support** - Use ASCII diagrams in code blocks for universal compatibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing Guide
 
-> **Important:** Always edit `.qmd` files, not `.md` files. The `.md` files are automatically generated when running `just update-chapters` and will be overwritten.
-
 ## When to Create ADRs
 
 **Create ADRs for foundational decisions only:**
@@ -21,11 +19,28 @@
 ## Quick Workflow
 
 1. **Open in Codespaces** → Automatic tool setup
-2. **Get number** → `just next-number` (provides next sequential number)
-3. **Create file** → `###-short-name.qmd` in correct directory ([see content types](#content-types-when-to-use-what))
+2. **Get number** → `just next-number`
+3. **Create file** → `###-short-name.md` in correct directory ([see content types](#content-types-when-to-use-what))
 4. **Write content** → Follow template below
-5. **Validate** → `just validate` and fix issues
-6. **Submit PR** → Ready for review (chapters auto-update)
+5. **Lint** → `just lint` to fix formatting, check SUMMARY.md, and validate links
+6. **Add to SUMMARY.md** → Include new ADR in navigation (required for mdBook)
+7. **Submit PR** → Ready for review
+
+**ADR Creation Workflow:**
+
+```text
+┌─────────────┐    ┌──────────────┐    ┌─────────────────┐    ┌──────────────┐
+│   Setup     │───▶│   Create     │───▶│    Validate     │───▶│   Submit     │
+│ Environment │    │   Content    │    │   & Format      │    │     PR       │
+└─────────────┘    └──────────────┘    └─────────────────┘    └──────────────┘
+      │                    │                      │                     │
+      ▼                    ▼                      ▼                     ▼
+┌─────────────┐    ┌──────────────┐    ┌─────────────────┐    ┌──────────────┐
+│ • Codespace │    │ • Get number │    │ • just lint     │    │ • Add to     │
+│ • Clone     │    │ • Template   │    │ • Format/links  │    │   SUMMARY.md │
+│ • Tools     │    │ • Directory  │    │ • Build test    │    │ • Review     │
+└─────────────┘    └──────────────┘    └─────────────────┘    └──────────────┘
+```
 
 ## Directory Structure
 
@@ -41,13 +56,13 @@
 ### ADRs (Architecture Decision Records)
 
 **Purpose**: Document foundational technology decisions that are expensive to change  
-**Format**: `###-decision-name.qmd` in `development/`, `operations/`, or `security/`  
+**Format**: `###-decision-name.md` in `development/`, `operations/`, or `security/`  
 **Examples**: "AWS EKS for workloads", "Secrets management approach", "API standards"
 
 ### Reference Architectures  
 
 **Purpose**: Project kickoff templates that combine multiple existing ADRs  
-**Format**: `descriptive-name.qmd` in `reference-architectures/`  
+**Format**: `descriptive-name.md` in `reference-architectures/`  
 **Examples**: "Content Management", "Data Pipelines", "Identity Management"
 
 **Rule**: Reference architectures should only link to existing ADRs, not create new ones.
@@ -55,14 +70,9 @@
 ## ADR Template
 
 ```markdown
----
-title: "ADR ###: Specific Decision Title"
-date: 2025-07-22
-status: Proposed
-tags: [category, technology]
----
+# ADR ###: Specific Decision Title
 
-**Status:** {{< meta status >}} | **Date:** {{< meta date >}}
+**Status:** Proposed | **Date:** YYYY-MM-DD
 
 ## Context
 What problem are we solving? Include background and constraints.
@@ -84,18 +94,21 @@ What we decided and how to implement it:
 - Risk 2 with mitigation
 ```
 
-**Important**: Tags should NOT be prefixed with # to avoid YAML parsing errors  
+**Status Options:**
+
+- `Accepted` - Decision is final and implemented
+- `Proposed` - Under review or discussion
+- `Rejected` - Decision was declined
+- `Superseded` - Replaced by newer ADR
+
 **Note**: ADR numbers are globally unique across all directories (gaps from removed drafts are normal)
 
 ## Reference Architecture Template
 
 ```markdown
----
-title: "Reference Architecture: Pattern Name"
-date: 2025-07-28
-status: Proposed
-tags: [reference, technology, domain]
----
+# Reference Architecture: Pattern Name
+
+**Status:** Proposed | **Date:** YYYY-MM-DD
 
 ## When to Use This Pattern
 Clear use case description for when to apply this architecture.
@@ -104,17 +117,17 @@ Clear use case description for when to apply this architecture.
 Brief template description focusing on practical implementation.
 
 ## Core Components
-```mermaid
-graph TB
-    Component1[Source] --> Component2[Process]
-    Component2 --> Component3[Output]
-```
+┌─────────┐    ┌─────────┐    ┌─────────┐
+│ Source  │───▶│ Process │───▶│ Output  │
+└─────────┘    └─────────┘    └─────────┘
 
 ## Project Kickoff Steps
 
-1. **Step Name** - Follow [ADR ###: Title](../category/###-filename.qmd) for implementation
+1. **Step Name** - Follow [ADR ###: Title](../category/###-filename.md) for implementation
 2. **Next Step** - *ADR needed for missing standards*
 3. **Final Step** - Reference to existing practices
+
+```
 
 ## Quality Standards
 
@@ -123,7 +136,7 @@ graph TB
 - [ ] Title is concise (under 50 characters) and actionable
 - [ ] All acronyms defined on first use
 - [ ] Active voice (not passive)
-- [ ] Passes `just validate` without errors
+- [ ] Passes `just lint` without errors
 
 **Title Examples:**
 
@@ -134,15 +147,13 @@ graph TB
 
 ## Commands
 
-```bash
-just next-number      # Get next ADR number (auto-increments from highest)
-just validate        # Check format + prose quality (5 validation tools)
-just serve          # Preview website locally (port 8080)
-just clean          # Remove generated files
-just update-chapters  # Refresh _quarto.yml chapters (auto-runs on build)
-```
+Run `just` to see all available commands.
 
-**Validation includes**: markdownlint, Vale style, frontmatter schema, yq parsing, and custom checks
+**Quick setup:**
+
+```bash
+./scripts/setup.sh   # Automated setup script
+```
 
 ## Status Guide
 
@@ -154,24 +165,16 @@ just update-chapters  # Refresh _quarto.yml chapters (auto-runs on build)
 
 ## ADR References
 
-**In frontmatter (for strong relationships):**
+**Reference format:**
 
-```yaml
-supersedes: "012"     # This ADR replaces ADR 012
-related: ["005", "007"]  # Related to ADRs 005 and 007
-```
-
-**In text (for implementation details):**
-
-- Reference format: `[ADR 005: Secrets Management](../security/005-secrets-management.qmd)`
+- `[ADR 005: Secrets Management](../security/005-secrets-management.md)`
 - Quick reference: `per ADR 005`
 - Multiple refs: `aligned with ADR 001 and ADR 005`
 
 **Examples:**
 
-- Implementation: "Encryption handled per [ADR 005: Secrets Management](../security/005-secrets-management.qmd)"
-- Quick mention: "Access controls aligned with ADR 001"
-- Multiple: "Following standards from ADR 003 and ADR 009"
+- "Encryption handled per [ADR 005: Secrets Management](security/005-secrets-management.md)"
+- "Access controls aligned with ADR 001"
 
 ## Writing Tips
 
@@ -180,29 +183,18 @@ related: ["005", "007"]  # Related to ADRs 005 and 007
 - **Define scope**: What's included and excluded
 - **Reference standards**: Link to external docs
 - **Use Australian English**: "organisation" not "organization", "colour" not "color"
+- **Character usage**: Use plain-text safe Unicode (box-drawing ┌─┐ is fine) but avoid emoji, smart quotes (""),  
+  em-dashes (—), and complex symbols for PDF compatibility
+- **Terminology**: Use Australian English ("organisation" not "organization") and "jurisdiction" instead of  
+  "government" for broad applicability
+- **ASCII diagrams**: Use box drawing characters (┌─┐│└┘) for universal compatibility
 
 ## Reference Architecture Guidelines
 
-**Purpose**: Project kickoff templates linking foundational ADRs for faster, consistent delivery
+**Purpose**: Project kickoff templates that combine existing ADRs
 
-**Consolidated Approach**:
-
-- **9-11 foundational steps maximum** linking to existing ADRs only
-- **Implementation Details section** for specifics that don't need ADRs
-- **Focus on high-cost-to-change decisions** (architectural patterns, technology standards, security frameworks)
-- **Avoid creating ADRs** for implementation details that can be handled in documentation
-
-**Structure**:
-
-- **When to Use**: Clear use case description
-- **Overview**: Brief template description  
-- **Core Components**: Mermaid diagram showing architecture flow
-- **Project Kickoff Steps**: Foundational ADRs grouped by logical sections (Foundation, Security, Development)
-- **Implementation Details**: Bullet points for project-specific guidance
-
-**Content Rules**:
-
-- Link to existing foundational ADRs only
-- Use "Implementation Details" for specifics instead of creating new ADRs
-- Consolidate related concerns into existing comprehensive ADRs
+**Rules**:
+- Link to existing ADRs only (don't create new ones)
+- Keep steps focused (9-11 maximum)
+- Include architecture diagram
 - Use "jurisdiction" not "government" for broad applicability

--- a/README.md
+++ b/README.md
@@ -1,126 +1,43 @@
-# Architecture Decision Records
+# DGOV DTT Architecture Decision Records
 
-Architecture Decision Records (ADRs) for Office of Digital Government
-(DGOV) Digital Transformation and Technology Unit (DTT) infrastructure
-and platform operations.
+Architecture records and current decision state to support infrastructure and platform operations for Office of Digital
+Government (DGOV) Digital Transformation and Technology Unit (DTT).  
 
-> **Note:** `.qmd` files are the source of truth. The `.md` files are
-> automatically generated from `.qmd` files when running
-> `just update-chapters`.
+Supporting training material is available at the [DGOV Technical - DevSecOps Induction](https://soc.cyber.wa.gov.au/training/devsecops-induction/)
+(guided by the [WA Cyber Security Policy](https://www.wa.gov.au/government/publications/2024-wa-government-cyber-security-policy)).
 
-**Quick Start:** [Open in
-Codespaces](https://codespaces.new/wagov-dtt/architecture-decision-records)
-→ `just next-number` → Create ADR → `just validate` → Submit PR
+The [Architecture Principles](architecture-principles.md) guide all decisions documented here.
 
-[**View Full
-Documentation**](https://wagov-dtt.github.io/architecture-decision-records/)
-\| [**Download
-PDF**](https://github.com/wagov-dtt/architecture-decision-records/releases/latest)
+## Structure
 
-## ADR Index
+This project uses [mdBook](https://rust-lang.github.io/mdBook/) to generate documentation from markdown files:
 
-| ADR | Title | Status | Date |
-|----|----|----|----|
-| [ADR 001](security/001-isolation.md) | ADR 001: Application Isolation | Accepted | 2025-02-17 |
-| [ADR 002](operations/002-workloads.md) | ADR 002: AWS EKS for Cloud Workloads | Accepted | 2025-02-17 |
-| [ADR 003](development/003-apis.md) | ADR 003: API Documentation Standards | Accepted | 2025-03-26 |
-| [ADR 004](development/004-cicd.md) | ADR 004: CI/CD Quality Assurance | Accepted | 2025-03-10 |
-| [ADR 005](security/005-secrets-management.md) | ADR 005: Secrets Management | Accepted | 2025-02-25 |
-| [ADR 006](operations/006-policy-enforcement.md) | ADR 006: Automated Policy Enforcement | Proposed | 2025-07-29 |
-| [ADR 007](operations/007-logging.md) | ADR 007: Centralised Security Logging | Accepted | 2025-02-25 |
-| [ADR 008](security/008-email-authentication.md) | ADR 008: Email Authentication Protocols | Proposed | 2025-07-22 |
-| [ADR 009](development/009-release.md) | ADR 009: Release Documentation Standards | Accepted | 2025-03-04 |
-| [ADR 010](operations/010-configmgmt.md) | ADR 010: Infrastructure as Code | Accepted | 2025-03-10 |
-| [ADR 011](security/011-ai-governance.md) | ADR 011: AI Tool Governance | Proposed | 2025-07-29 |
-| [ADR 012](security/012-privileged-remote-access.md) | ADR 012: Privileged Remote Access | Proposed | 2025-07-22 |
-| [ADR 013](security/013-identity-federation.md) | ADR 013: Identity Federation Standards | Proposed | 2025-07-29 |
-| [ADR 014](operations/014-object-backup.md) | ADR 014: Object Storage Backups | Proposed | 2025-07-22 |
-| [ADR 015](operations/015-data-governance.md) | ADR 015: Data Governance Standards | Proposed | 2025-07-28 |
-| [ADR 016](security/016-edge-protection.md) | ADR 016: Web Application Edge Protection | Proposed | 2025-07-22 |
-| [ADR 017](operations/017-analytics-tooling.md) | ADR 017: Analytics Tooling Standards | Proposed | 2025-07-28 |
-| [ADR 018](operations/018-database-patterns.md) | ADR 018: Database Patterns | Proposed | 2025-07-28 |
+- **ADRs** are organized in directories by domain (`development/`, `operations/`, `security/`)
+- **Navigation** is defined in `SUMMARY.md`
+- **Build output** goes to `book/` directory
 
-### Reference Architectures
+## Quick Start
 
-| Reference | Title | Status | Date |
-|----|----|----|----|
-| [Content Management](reference-architectures/content-management.md) | Reference Architecture: Content Management | Proposed | 2025-07-28 |
-| [Data Pipelines](reference-architectures/data-pipelines.md) | Reference Architecture: Data Pipelines | Proposed | 2025-01-28 |
-| [Identity Management](reference-architectures/identity-management.md) | Reference Architecture: Identity Management | Proposed | 2025-07-29 |
-| [Openapi Backends](reference-architectures/openapi-backends.md) | Reference Architecture: OpenAPI Backend | Proposed | 2025-07-28 |
-
-## Quick Reference
-
-### Creating ADRs
-
-``` bash
-just next-number          # Get next ADR number
-just validate            # Check format and quality  
-just serve              # Preview website locally
-just clean              # Remove generated files
+```bash
+./scripts/setup.sh  # One-time setup
+just serve          # Preview locally (port 8080)
 ```
 
-### ADR Template
+Run `just` to see all available commands.
 
-``` markdown
----
-title: "ADR ###: Your Decision Title"
-date: 2025-07-22
-status: Proposed
-tags: [category, technology]
----
+**[View as PDF](book/pandoc/pdf/adr-guide.pdf)** | **[Browse online](https://wagov-dtt.github.io/architecture-decision-records/)**
 
-**Status:** ?meta:status | **Date:** ?meta:date
+## Development
 
-## Context
-What problem are we solving?
+First time setup requires installing tools - use the setup script for automated installation.
 
-## Decision  
-What did we decide and why?
+## Contributing
 
-## Consequences
-What are the trade-offs and risks?
-```
+New ADRs follow a structured format documenting the **context** (problem), **decision** (solution), and
+**consequences** (risks).
 
-## Title Examples
+1. Create new markdown file in appropriate directory (e.g., `security/019-new-topic.md`)
+2. Add entry to `SUMMARY.md` in the correct section
+3. Follow the ADR template structure
 
-**Good:** “ADR 008: Email Authentication”, “ADR 016: Edge Protection”,
-“ADR 006: Policy Enforcement”  
-**Bad:** “Database stuff”, “Security improvements”, “Frontend updates”
-
-## Development Commands
-
-| Command            | Purpose                        |
-|--------------------|--------------------------------|
-| `just next-number` | Get next ADR number to use     |
-| `just validate`    | Check format and prose quality |
-| `just serve`       | Preview website locally        |
-| `just build`       | Generate final website/PDF     |
-| `just clean`       | Remove generated files         |
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for complete workflow and quality
-standards.
-
-## Automated Deployment
-
-**Website:** Automatically deploys to GitHub Pages on every push to
-`main`  
-**PDF Releases:** Automatically attached to GitHub releases when
-published
-
-### Manual Deployment
-
-``` bash
-just build    # Build website and PDF locally
-```
-
-## Related Resources
-
-- [Architecture Principles](./architecture-principles.md) - Guide all
-  decisions
-- [DGOV DevSecOps
-  Training](https://soc.cyber.wa.gov.au/training/devsecops-induction/) -
-  Supporting material
-- [WA Cyber Security
-  Policy](https://www.wa.gov.au/government/publications/2024-wa-government-cyber-security-policy) -
-  Compliance framework
+See the [Contributing Guide](CONTRIBUTING.md) for complete workflow and quality standards.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,47 @@
+# Summary
+
+- [Introduction](README.md)
+- [Architecture Principles](architecture-principles.md)
+
+---
+
+# Development ADRs
+
+- [ADR 003: APIs](development/003-apis.md)
+- [ADR 004: CI/CD](development/004-cicd.md)
+- [ADR 009: Release](development/009-release.md)
+
+# Operations ADRs
+
+- [ADR 002: Workloads](operations/002-workloads.md)
+- [ADR 006: Policy Enforcement](operations/006-policy-enforcement.md)
+- [ADR 007: Logging](operations/007-logging.md)
+- [ADR 010: Config Management](operations/010-configmgmt.md)
+- [ADR 014: Object Backup](operations/014-object-backup.md)
+- [ADR 015: Data Governance](operations/015-data-governance.md)
+- [ADR 017: Analytics Tooling](operations/017-analytics-tooling.md)
+- [ADR 018: Database Patterns](operations/018-database-patterns.md)
+
+# Security ADRs
+
+- [ADR 001: Isolation](security/001-isolation.md)
+- [ADR 005: Secrets Management](security/005-secrets-management.md)
+- [ADR 008: Email Authentication](security/008-email-authentication.md)
+- [ADR 011: AI Governance](security/011-ai-governance.md)
+- [ADR 012: Privileged Remote Access](security/012-privileged-remote-access.md)
+- [ADR 013: Identity Federation](security/013-identity-federation.md)
+- [ADR 016: Edge Protection](security/016-edge-protection.md)
+
+---
+
+# Reference Architectures
+
+- [Content Management](reference-architectures/content-management.md)
+- [Data Pipelines](reference-architectures/data-pipelines.md)
+- [Identity Management](reference-architectures/identity-management.md)
+- [OpenAPI Backends](reference-architectures/openapi-backends.md)
+
+---
+
+- [Contributing](CONTRIBUTING.md)
+- [Glossary](glossary.md)

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,45 @@
+[book]
+title = "DGOV DTT Architecture Decision Records"
+authors = ["DGOV DTT"]
+description = "Architecture records and current decision state to support infrastructure and platform operations"
+src = "."
+
+[build]
+build-dir = "book"
+
+[output.html]
+no-section-label = true
+git-repository-url = "https://github.com/wagov-dtt/architecture-decision-records"
+edit-url-template = "https://github.com/wagov-dtt/architecture-decision-records/edit/main/{path}"
+
+[output.linkcheck]
+
+[output.pandoc]
+
+[output.pandoc.profile.pdf]
+output-file = "adr-guide.pdf"
+to = "latex"
+pdf-engine = "lualatex"
+number-sections = false
+
+[output.pandoc.profile.pdf.variables]
+documentclass = "article"
+papersize = "a4"
+geometry = "margin=2cm"
+mainfont = "DejaVu Sans"
+monofont = "DejaVu Sans Mono"
+fontsize = "10pt"
+linkcolor = "blue!70"
+urlcolor = "blue!70"
+colorlinks = true
+secnumdepth = 0
+linestretch = "1.15"
+indent = false
+block-headings = true
+# Code block styling
+listings = true
+backgroundcolor = "lightgray"
+# Table styling
+tables = true
+# Modern spacing optimized for A4
+parskip = "4pt"

--- a/development/004-cicd.md
+++ b/development/004-cicd.md
@@ -1,18 +1,6 @@
----
-title: 'ADR 004: CI/CD Quality Assurance'
-date: 2025-03-10T00:00:00.000Z
-status: Accepted
-tags:
-  - ci/cd
-  - security
-  - containers
-related:
-  - '010'
-  - '003'
----
+# ADR 004: CI/CD Quality Assurance
 
-
-**Status:** Accepted \| **Date:** 2025-03-10
+**Status:** Accepted | **Date:** 2025-03-10
 
 ## Context
 
@@ -31,7 +19,23 @@ images, misconfigurations, and exposed secrets.
 To address these risks, use a CI/CD pipeline with the following
 standardised practices (or similar equivalents) before releasing code
 and build artifacts to release via [ADR 010: Infrastructure as
-Code](../operations/010-configmgmt.qmd):
+Code](../operations/010-configmgmt.md):
+
+**CI/CD Pipeline Flow:**
+
+```text
+┌─────────────┐    ┌──────────────┐    ┌─────────────────┐    ┌──────────────┐
+│   Code      │───▶│    Build     │───▶│   Quality       │───▶│   Release    │
+│   Commit    │    │   & Test     │    │   Assurance     │    │   & Deploy   │
+└─────────────┘    └──────────────┘    └─────────────────┘    └──────────────┘
+                          │                      │                     │
+                          ▼                      ▼                     ▼
+                   ┌─────────────┐    ┌─────────────────┐    ┌─────────────────┐
+                   │  • Semgrep  │    │ • Trivy scan    │    │ • Cosign        │
+                   │  • Playwright│    │ • K6 tests      │    │ • Auto-patch    │
+                   │  • Restish  │    │ • OWASP checks  │    │ • Deployment    │
+                   └─────────────┘    └─────────────────┘    └─────────────────┘
+```
 
 - Use [GitHub
   Actions](https://docs.github.com/en/actions/about-github-actions/understanding-github-actions)
@@ -49,7 +53,7 @@ Code](../operations/010-configmgmt.qmd):
 - Use [Playwright](https://playwright.dev/docs/intro) for **end-to-end
   testing of web applications**.
 - Use [Restish](https://rest.sh/#/guide) for **scripted validation of
-  [ADR 003: API Documentation Standards](../development/003-apis.qmd)**.
+  [ADR 003: API Documentation Standards](../development/003-apis.md)**.
 - Use [Grafana
   K6](https://grafana.com/docs/k6/latest/get-started/write-your-first-test/)
   for **performance and reliability testing**.

--- a/justfile
+++ b/justfile
@@ -1,125 +1,42 @@
 # Architecture Decision Records
+# Documentation build and validation system
 
 # Show available commands
 default:
     @just --list
 
-# Build website and PDF from ADRs
-build: update-chapters
-    quarto render
-    @echo "Checking links..."
-    @lychee --no-progress '_site/**/*.html' || echo "Link check failed"
+# === Build Commands ===
 
-# Update _quarto.yml with current ADR files
-update-chapters:
-    #!/bin/bash
-    # Update git hash and chapters in _quarto.yml (prefer tag over commit)
-    git_ref=$(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
-    yq eval ".git-hash = \"$git_ref\"" -i _quarto.yml
-    yq eval '.book.chapters = ["index.qmd", "architecture-principles.md"]' -i _quarto.yml
-    # Process ADR directories first (exclude reference-architectures)
-    for dir in */; do
-      dir=${dir%/}  # Remove trailing slash
-      if [[ "$dir" != "reference-architectures" ]] && ls $dir/*.qmd 1> /dev/null 2>&1; then
-        title="$(echo ${dir^} ADRs)"
-        yq eval ".book.chapters += [{\"part\": \"$title\", \"chapters\": []}]" -i _quarto.yml
-        for file in $(ls $dir/*.qmd | sort -V); do
-          yq eval ".book.chapters[-1].chapters += [\"$file\"]" -i _quarto.yml
-        done
-      fi
-    done
-    # Process reference-architectures at the end
-    if ls reference-architectures/*.qmd 1> /dev/null 2>&1; then
-      yq eval '.book.chapters += [{"part": "Reference Architectures", "chapters": []}]' -i _quarto.yml
-      for file in $(ls reference-architectures/*.qmd | sort -V); do
-        yq eval ".book.chapters[-1].chapters += [\"$file\"]" -i _quarto.yml
-      done
-    fi
-    yq eval '.book.chapters += ["CONTRIBUTING.md", "glossary.md"]' -i _quarto.yml
-    
-    echo "Running markdownlint..."
-    markdownlint --fix */*.qmd *.qmd CONTRIBUTING.md AGENT.md README.md || echo "Markdown formatting suggestions found"
-    
-    # Render all .qmd files to .md using GFM profile
-    echo "Generating all .md files using Quarto GFM profile..."
-    quarto render --profile gfm
-    
-    # Generate ADR index file (now that .md files exist)
-    echo "Generating _adr-index.md..."
-    
-    # Create markdown table from ADR frontmatter
-    echo "| ADR | Title | Status | Date |" > _adr-index.md
-    echo "|-----|-------|--------|------|" >> _adr-index.md
-    
-    # Process ADRs by number order
-    for file in $(find . -name "[0-9][0-9][0-9]-*.qmd" | sed 's/.*\/\([0-9][0-9][0-9]\)-\(.*\)/\1 &/' | sort -n | cut -d' ' -f2-); do
-      if [ -f "$file" ]; then
-        number=$(basename "$file" | sed 's/\([0-9][0-9][0-9]\)-.*/\1/')
-        title=$(yq --front-matter=extract eval '.title' "$file" 2>/dev/null | sed 's/^"ADR [0-9]*: //' | sed 's/"$//')
-        status=$(yq --front-matter=extract eval '.status' "$file" 2>/dev/null)
-        date=$(yq --front-matter=extract eval '.date' "$file" 2>/dev/null)
-        relative_path="${file#./}"
-        md_path="${relative_path%.qmd}.md"
-        echo "| [ADR ${number}]($md_path) | $title | $status | $date |" >> _adr-index.md
-      fi
-    done
-    
-    # Add Reference Architectures section
-    echo "" >> _adr-index.md
-    echo "### Reference Architectures" >> _adr-index.md
-    echo "" >> _adr-index.md
-    echo "| Reference | Title | Status | Date |" >> _adr-index.md
-    echo "|-----------|-------|--------|------|" >> _adr-index.md
-    
-    for file in $(ls reference-architectures/*.qmd 2>/dev/null | sort); do
-      if [ -f "$file" ]; then
-        title=$(yq --front-matter=extract eval '.title' "$file" 2>/dev/null | sed 's/^"Reference Architecture: //' | sed 's/"$//')
-        status=$(yq --front-matter=extract eval '.status' "$file" 2>/dev/null)
-        date=$(yq --front-matter=extract eval '.date' "$file" 2>/dev/null)
-        basename_title=$(basename "$file" .qmd | tr '-' ' ' | sed 's/.*/\L&/; s/[a-z]*/\u&/g')
-        md_path="${file%.qmd}.md"
-        echo "| [$basename_title]($md_path) | $title | $status | $date |" >> _adr-index.md
-      fi
-    done
-    
-    # Re-render README.qmd with the updated index
-    echo "Re-generating README.md with updated index..."
-    quarto render --profile gfm README.qmd
+# Build documentation website (includes link checking)
+build:
+    mdbook build
 
-# Start development server (static build)
-serve: build
-    cd _site && python3 -m http.server 8080
+# Serve documentation locally (port 8080)
+serve:
+    mdbook serve --port 8080
 
 # Clean generated files
 clean:
-    rm -rf _site/
+    mdbook clean
 
-# Full validation
-validate:
-    vale sync
-    @find . -name "*.qmd" -path "./*/[0-9][0-9][0-9]-*.qmd" -exec grep -L "^---$" {} \; | \
-    if read file; then echo "Missing frontmatter: $file"; exit 1; else echo "Frontmatter valid"; fi
-    @echo "Validating ADR frontmatter schemas..."
-    @for file in */[0-9][0-9][0-9]-*.qmd; do \
-      if [ -f "$$file" ]; then \
-        yq eval '.title, .date, .status' "$$file" > /dev/null || echo "Invalid frontmatter in $$file"; \
-      fi \
-    done
-    @markdownlint */*.qmd *.qmd CONTRIBUTING.md AGENT.md README.md || echo "Markdown formatting suggestions found"
-    @vale --no-exit --ignore-syntax *.qmd */*.qmd CONTRIBUTING.md AGENT.md README.md --glob='!glossary.qmd' || echo "Style suggestions found"
+# === Quality Commands ===
 
-# Create/update git release tag
-release TAG="":
-    #!/bin/bash
-    if [ -z "{{TAG}}" ]; then
-      tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
-    else
-      tag="{{TAG}}"
-    fi
-    echo "Updating tag: $tag"
-    git tag -f "$tag"
-    git push -f origin "$tag"
+# Lint and fix formatting issues
+lint:
+    rumdl check --fix .
+    @echo "Checking SUMMARY.md completeness..."
+    @./scripts/check-summary.sh
+    @echo "Checking links (via build)..."
+    @mdbook build
 
-# Get next ADR number
+# === Setup Commands ===
+
+# Install required tools (first time)
+setup:
+    cargo install rumdl mdbook mdbook-pandoc mdbook-linkcheck
+
+# === Development Commands ===
+
+# Get next global ADR number
 next-number:
-    @find . -name "[0-9][0-9][0-9]-*.qmd" | sed 's/.*\/\([0-9][0-9][0-9]\)-.*/\1/' | sort -n | tail -1 | awk '{printf "%03d\n", $1+1}'
+    @printf "%03d\n" $$(($$(find development operations security -name "*.md" | grep -o '[0-9]\+' | sort -n | tail -1) + 1))

--- a/operations/010-configmgmt.md
+++ b/operations/010-configmgmt.md
@@ -1,19 +1,6 @@
----
-title: 'ADR 010: Infrastructure as Code'
-date: 2025-03-10T00:00:00.000Z
-status: Accepted
-tags:
-  - infrastructure
-  - security
-  - iac
-related:
-  - '001'
-  - '005'
-  - '002'
----
+# ADR 010: Infrastructure as Code
 
-
-**Status:** Accepted \| **Date:** 2025-03-10
+**Status:** Accepted | **Date:** 2025-03-10
 
 ## Context
 
@@ -45,9 +32,9 @@ management:
   configuration management
 - Use [Justfiles](https://just.systems/man/en/) for operations task
   automation
-- Follow [ADR 001: Application Isolation](../security/001-isolation.qmd)
+- Follow [ADR 001: Application Isolation](../security/001-isolation.md)
   and [ADR 005: Secrets
-  Management](../security/005-secrets-management.qmd)
+  Management](../security/005-secrets-management.md)
 
 ### State Management & Git Workflow
 
@@ -60,6 +47,36 @@ management:
   backup
 - Branch protection rules and required reviews for configuration changes
 
+**Infrastructure as Code Workflow:**
+
+```text
+┌───────────┐    ┌──────────────┐    ┌─────────────────┐    ┌──────────────┐
+│    Git    │───▶│   Security   │───▶│   Deployment    │───▶│ Environment  │
+│  Changes  │    │  Validation  │    │   Pipeline      │    │   Update     │
+└───────────┘    └──────────────┘    └─────────────────┘    └──────────────┘
+      │                  │                     │                      │
+      ▼                  ▼                     ▼                      ▼
+┌───────────┐    ┌──────────────┐    ┌─────────────────┐    ┌──────────────┐
+│ • PR      │    │ • Trivy scan │    │ • State lock    │    │ • Dev/Test   │
+│ • Review  │    │ • Drift      │    │ • Plan review   │    │ • Staging    │
+│ • Tag     │    │   detection  │    │ • Apply changes │    │ • Production │
+└───────────┘    └──────────────┘    └─────────────────┘    └──────────────┘
+
+Environment State Storage:
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│     Dev     │    │   Staging   │    │ Production  │
+│   State     │    │    State    │    │    State    │
+│ (Isolated)  │    │ (Isolated)  │    │ (Isolated)  │
+└─────────────┘    └─────────────┘    └─────────────┘
+       │                   │                   │
+       └───────────────────┼───────────────────┘
+                           ▼
+                 ┌─────────────────┐
+                 │   Cross-region  │
+                 │     Backup      │
+                 └─────────────────┘
+```
+
 ### Deployment Consistency
 
 - Each environment deployable from specific git tag
@@ -67,7 +84,7 @@ management:
   deployment
 - Test releases locally with [k3d](https://k3d.io/stable/) and on EKS
   per [ADR 002: AWS EKS for Cloud
-  Workloads](../operations/002-workloads.qmd)
+  Workloads](../operations/002-workloads.md)
 
 ## Consequences
 

--- a/scripts/check-summary.sh
+++ b/scripts/check-summary.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Check that all markdown files are included in SUMMARY.md
+
+exit_code=0
+
+for file in $(find development operations security reference-architectures -name "*.md"); do
+    if ! grep -q "$file" SUMMARY.md; then
+        echo "Missing: $file"
+        exit_code=1
+    fi
+done
+
+exit $exit_code

--- a/security/013-identity-federation.md
+++ b/security/013-identity-federation.md
@@ -1,18 +1,6 @@
----
-title: 'ADR 013: Identity Federation Standards'
-date: 2025-07-29T00:00:00.000Z
-status: Proposed
-tags:
-  - identity
-  - federation
-  - oidc
-  - saml
-related:
-  - '007'
----
+# ADR 013: Identity Federation Standards
 
-
-**Status:** Proposed \| **Date:** 2025-07-29
+**Status:** Proposed | **Date:** 2025-07-29
 
 ## Context
 
@@ -26,12 +14,9 @@ Modern identity federation requires support for emerging standards like
 verifiable credentials while maintaining compatibility with legacy
 enterprise systems.
 
-- [Digital ID Act
-  2024](https://www.legislation.gov.au/Details/C2024A00069)
-- [OpenID Connect Core
-  1.0](https://openid.net/specs/openid-connect-core-1_0.html)
-- [OWASP Authentication Cheat
-  Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+- [Digital ID Act 2024](https://www.legislation.gov.au/Details/C2024A00069)
+- [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
+- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
 
 ## Decision
 
@@ -59,6 +44,27 @@ systems that cannot support OIDC.
 - Support multiple upstream identity providers per application
 - Maintain audit trails distinguishing privileged from standard user
   activities
+
+**Identity Federation Flow:**
+
+```text
+┌─────────────┐    ┌─────────────────┐    ┌─────────────────┐    ┌─────────────┐
+│   Users     │───▶│    Identity     │───▶│    Managed      │───▶│ Application │
+│ (Citizens/  │    │   Providers     │    │   Platform      │    │   Services  │
+│ Enterprise) │    │                 │    │                 │    │             │
+└─────────────┘    └─────────────────┘    └─────────────────┘    └─────────────┘
+                          │                       │                      │
+                          ▼                       ▼                      ▼
+                   ┌─────────────┐        ┌──────────────┐       ┌─────────────┐
+                   │ • OIDC/SAML │        │ • Token mgmt │       │ • RBAC      │
+                   │ • Verifiable│        │ • Protocol   │       │ • Audit log │
+                   │   Credential│        │   translate  │       │ • Session   │
+                   │ • Legacy IdP│        │ • Audit log  │       │   mgmt      │
+                   └─────────────┘        └──────────────┘       └─────────────┘
+
+Privileged Domain ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Standard Domain   ────────────────────────────────────────────────────────────
+```
 
 **Emerging Standards:**
 
@@ -88,4 +94,4 @@ systems that cannot support OIDC.
 - Choose identity platforms with high availability and data export
   capabilities
 - Maintain audit trails following [ADR 007: Centralized Security
-  Logging](../operations/007-logging.qmd)
+  Logging](../operations/007-logging.md)


### PR DESCRIPTION
- Replace Quarto with mdBook for simpler documentation generation
- Add comprehensive link checking via mdbook-linkcheck backend
- Include ASCII diagrams for key workflows (CI/CD, identity federation, infrastructure)
- Configure A4 PDF format
- Simplify commands: just build, just lint, just serve
- Update GitHub Actions workflow for mdBook deployment
- Add SUMMARY.md for manual navigation control