### PR TITLE
Reframe architecture principles as ADR design guardrails

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ AI tools may help draft or review ADRs, but a human contributor remains
 responsible for the final content.
 
 - Prefer isolated or local AI tooling per [ADR 011: AI Tool and Agent Governance](security/011-ai-governance.md)
-- Review [architecture-principles.md](architecture-principles.md) before proposing changes
+- Review [adr-design-guardrails.md](adr-design-guardrails.md) before proposing changes
 - Browse [reference-architectures/](reference-architectures/) for project kickoff patterns
 - Check existing ADRs in `development/`, `operations/`, and `security/` before creating new guidance
 - Human review is required for all AI-generated changes before merge

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ These patterns help you build secure, compliant digital services faster. Instead
 
 ### Getting Started
 
-1. **Review the [Architecture Principles](architecture-principles.md)** - Six guiding principles for all technology decisions
+1. **Review the [ADR Design Guardrails](adr-design-guardrails.md)** - Six guiding principles for all technology decisions
 2. **Choose a Reference Architecture** - Project kickoff templates combining multiple decisions:
    - [Content Management](reference-architectures/content-management.md) - Websites, intranets, and content portals
    - [Data Pipelines](reference-architectures/data-pipelines.md) - Analytics, reporting, and data processing

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,7 +1,7 @@
 # Summary
 
 - [Introduction](README.md)
-- [Architecture Principles](architecture-principles.md)
+- [ADR Design Guardrails](adr-design-guardrails.md)
 
 ---
 

--- a/adr-design-guardrails.md
+++ b/adr-design-guardrails.md
@@ -1,8 +1,11 @@
-# Architecture Principles
+# ADR Design Guardrails
 
 **Status:** Accepted | **Date:** 2025-03-07
 
-These six principles guide all architecture decisions in this repository. Each ADR should align with one or more of these principles.
+These six guardrails guide day-to-day technical design decisions in this repository. They help teams make consistent
+trade-offs when writing and reviewing Architecture Decision Records (ADRs).
+
+They are not enterprise architecture principles, procurement policies, or technology standards for whole-of-government or agency-level use.
 
 ## 1. Establish secure foundations
 


### PR DESCRIPTION
## Summary
- rename Architecture Principles to ADR Design Guardrails
- clarify these are day-to-day ADR decision guardrails, not enterprise architecture or procurement policy
- update README, SUMMARY, and CONTRIBUTING links

## Checks
- searched for old filename/title references
- reviewed git diff before commit