### PR TITLE
Add AI-assisted digital services reference architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These patterns help you build secure, compliant digital services faster. Instead
 1. **Review the [ADR Design Guardrails](adr-design-guardrails.md)** - Six guiding principles for all technology decisions
 2. **Use the [Decision Finder](decision-finder.md)** - Match a project need to the right ADRs and reference architectures
 3. **Choose a Reference Architecture** - Project kickoff templates combining multiple decisions:
+   - [AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md) - Low-risk AI assistance for services, staff workflows, CMS, and portals
    - [Content Management](reference-architectures/content-management.md) - Websites, intranets, and content portals
    - [Data Pipelines](reference-architectures/data-pipelines.md) - Analytics, reporting, and data processing
    - [Federated Application Portal](reference-architectures/federated-application-portal.md) - Standalone apps using shared account, identity, notification, and SDK services
@@ -24,6 +25,7 @@ These patterns help you build secure, compliant digital services faster. Instead
 
 | If you need to... | Start with |
 |-------------------|------------|
+| Add AI assistance to a digital service or staff workflow | [AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md) |
 | Launch a public website, intranet, or portal | [Content Management](reference-architectures/content-management.md) |
 | Federate multiple standalone apps with shared account, identity, notification, or SDK services | [Federated Application Portal](reference-architectures/federated-application-portal.md) |
 | Build reports, analytics, or data processing | [Data Pipelines](reference-architectures/data-pipelines.md) |

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,11 +35,13 @@
 - [ADR 003: APIs](development/003-apis.md)
 - [ADR 004: CI/CD](development/004-cicd.md)
 - [ADR 009: Release Standards](development/009-release.md)
+- [ADR 020: Frontend UI Foundations](development/020-frontend-ui-foundations.md)
 
 ---
 
 # Reference Architectures
 
+- [AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md)
 - [Content Management](reference-architectures/content-management.md)
 - [Data Pipelines](reference-architectures/data-pipelines.md)
 - [Federated Application Portal](reference-architectures/federated-application-portal.md)

--- a/compliance-mapping.md
+++ b/compliance-mapping.md
@@ -28,6 +28,12 @@ The [ACSC Careful adoption of agentic AI services](https://www.cyber.gov.au/busi
 |-----|--------------------|
 | [011 AI Tool and Agent Governance](security/011-ai-governance.md) | Low-risk adoption, least privilege, human approval gates, sandbox testing, monitoring and audit logs, trusted component inventories, isolation of high-risk agents |
 
+Use [AI-Assisted Digital
+Services](reference-architectures/ai-assisted-digital-services.md) for
+service-facing AI implementations that need an Open Responses-compatible
+gateway, provider portability, data minimisation, and human-in-the-loop
+operation.
+
 ## WA Government Cyber Security Policy (WA CSP)
 
 The [2024 WA Government Cyber Security Policy](https://www.wa.gov.au/government/publications/2024-wa-government-cyber-security-policy) defines baseline cyber security requirements for WA Government entities.

--- a/decision-finder.md
+++ b/decision-finder.md
@@ -10,6 +10,7 @@ directly when you need a specific decision or control.
 
 | Project need | Start here | Then check |
 |--------------|------------|------------|
+| AI assistance for drafting, summarising, content review, form help, staff support, or low-risk productivity | [AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md) | [ADR 011: AI Tool and Agent Governance](security/011-ai-governance.md), [ADR 015: Data Governance](operations/015-data-governance.md), [ADR 007: Logging](operations/007-logging.md) |
 | Public website, intranet, or content portal | [Content Management](reference-architectures/content-management.md) | [ADR 016: Edge Protection](security/016-edge-protection.md), [ADR 013: Identity Federation](security/013-identity-federation.md), [ADR 015: Data Governance](operations/015-data-governance.md) |
 | Multiple standalone web apps sharing central account, identity, notification, SDK, or mobile-webview services | [Federated Application Portal](reference-architectures/federated-application-portal.md) | [Identity Management](reference-architectures/identity-management.md), [OpenAPI Backends](reference-architectures/openapi-backends.md), [ADR 016: Edge Protection](security/016-edge-protection.md) |
 | Data integration, analytics, reporting, or batch processing | [Data Pipelines](reference-architectures/data-pipelines.md) | [ADR 015: Data Governance](operations/015-data-governance.md), [ADR 018: Database Patterns](operations/018-database-patterns.md), [ADR 017: Analytics Tooling](operations/017-analytics-tooling.md) |
@@ -23,7 +24,9 @@ directly when you need a specific decision or control.
 | Application isolation and boundaries | [ADR 001: Isolation](security/001-isolation.md) |
 | Cloud workloads and runtime hosting | [ADR 002: Workloads](operations/002-workloads.md) |
 | API contracts and documentation | [ADR 003: APIs](development/003-apis.md) |
+| AI model access and provider-portable inference | [AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md), [ADR 011: AI Tool and Agent Governance](security/011-ai-governance.md) |
 | Build, test, and deployment automation | [ADR 004: CI/CD](development/004-cicd.md), [ADR 009: Release Standards](development/009-release.md) |
+| Frontend UI, design-system components, CMS templates, or portal widgets | [ADR 020: Frontend UI Foundations](development/020-frontend-ui-foundations.md) |
 | Secrets and credential handling | [ADR 005: Secrets Management](security/005-secrets-management.md) |
 | Policy-as-code and guardrails | [ADR 006: Policy Enforcement](operations/006-policy-enforcement.md) |
 | Centralised logging and monitoring | [ADR 007: Logging](operations/007-logging.md) |

--- a/development/020-frontend-ui-foundations.md
+++ b/development/020-frontend-ui-foundations.md
@@ -1,0 +1,118 @@
+# ADR 020: Frontend UI Foundations
+
+**Status:** Proposed | **Date:** 2026-06-17 | **Review:** 2027-06-17
+
+## Context
+
+WA Government digital services need consistent, accessible, maintainable web
+interfaces across public websites, portals, CMS templates, preview tools,
+widgets, and staff-facing applications. Teams often need to integrate with
+existing CMS platforms, third-party widgets, agency design systems, and
+independently delivered applications.
+
+Bespoke component systems can create avoidable maintenance burden, accessibility
+regressions, lock-in to a frontend framework, and integration problems for CMS
+or portal use cases. A mature, standards-based UI foundation helps teams build
+quickly while keeping semantic HTML, progressive enhancement, and WCAG 2.2 AA
+support visible.
+
+Bootstrap 5 is a mature, widely adopted frontend toolkit with documented layout,
+forms, components, helpers, utilities, and accessibility guidance. Its
+documentation notes that accessible outcomes still depend on correct author
+markup, styling, scripting, and colour choices. This makes Bootstrap a useful
+baseline, not a substitute for accessibility testing or design-system review.
+
+## Decision
+
+Prefer semantic HTML and Bootstrap 5-compatible component conventions for WA
+Government digital service web interfaces, unless an agency design system or
+product constraint requires a documented alternative.
+
+This does not require every service to import Bootstrap directly. A service may
+use an agency design system, theme, static-site template, web component, or
+framework-specific wrapper where it preserves Bootstrap-compatible structure,
+behaviour expectations, and accessibility semantics where practical.
+
+Frontend UI foundations must:
+
+- Start with semantic HTML, accessible names, keyboard support, and progressive
+  enhancement
+- Meet WCAG 2.2 AA for user-facing interfaces
+- Prefer Bootstrap 5-compatible layout, form, navigation, alert, modal, table,
+  and utility conventions where a component is needed
+- Keep CSS and JavaScript scoped to avoid interfering with CMS editors,
+  third-party widgets, portal shells, embedded applications, and preview tools
+- Avoid bespoke component libraries unless there is a documented user,
+  accessibility, brand, or integration need
+- Keep design-system styling separate from business logic and service APIs
+
+## Implementation Guidance
+
+Use Bootstrap 5-compatible conventions as a baseline for:
+
+- CMS templates, static previews, and review tooling
+- Portal shells, account widgets, inbox widgets, and SDK-provided UI
+- Standalone staff tools, AI review companions, and administrative interfaces
+- Static sites, generated reports, and file-review outputs where HTML is used
+
+Agency design systems should wrap or theme the baseline rather than force each
+service to create incompatible components. Where a different frontend framework
+is used, keep generated HTML and interaction behaviour compatible with the
+documented design-system components where practical.
+
+For CMS and review workflows, prefer [Hugo](https://gohugo.io/) where a simple,
+reliable static site generator is enough. Hugo provides fast local builds,
+modular themes, and [content
+adapters](https://gohugo.io/content-management/content-adapters/) that can
+dynamically create pages from remote or file-based data sources such as JSON,
+TOML, YAML, or XML. This makes it practical to plug preview and review tools
+into existing content libraries without requiring deep CMS changes.
+
+[Docsy](https://www.docsy.dev/) is a useful reference implementation for Hugo
+technical documentation and preview sites. It is a Hugo theme designed for
+technical documentation and uses the Hugo module workflow. Use Docsy as a
+reference for modular Hugo site structure, not as a mandatory theme for all
+public services.
+
+For Drupal-backed content platforms, the contributed [Bootstrap 5
+theme](https://www.drupal.org/project/bootstrap5) is a useful reference for
+aligning Drupal theme work with Bootstrap 5 conventions. Drupal project pages
+may require browser JavaScript to view, so confirm module status, maintenance,
+and compatibility in the normal Drupal review process before adoption.
+
+Do not use this ADR to override agency brand, accessibility, or content design
+requirements. Document deviations when another component library, framework,
+or native platform design system is a better fit.
+
+## Consequences
+
+**Benefits:**
+
+- Reduces bespoke UI and component maintenance
+- Improves portability across CMS, portal, static preview, and standalone tool
+  contexts
+- Supports accessible, semantic, progressively enhanced interfaces
+- Lowers integration risk with third-party widgets and independently owned apps
+- Gives teams a clear default without blocking agency-specific design systems
+
+**Risks if not implemented:**
+
+- Inconsistent UI foundations across related services
+- Increased accessibility and regression testing burden
+- Harder CMS, portal, and widget integration
+- More bespoke frontend code to maintain and secure
+
+## Related Reference Architectures
+
+- [AI-Assisted Digital Services](../reference-architectures/ai-assisted-digital-services.md)
+- [Content Management](../reference-architectures/content-management.md)
+- [Federated Application Portal](../reference-architectures/federated-application-portal.md)
+
+## References
+
+- [Bootstrap 5 documentation](https://getbootstrap.com/docs/5.3/getting-started/introduction/)
+- [Bootstrap 5 accessibility guidance](https://getbootstrap.com/docs/5.3/getting-started/accessibility/)
+- [Web Content Accessibility Guidelines 2.2](https://www.w3.org/TR/WCAG22/)
+- [Hugo content adapters](https://gohugo.io/content-management/content-adapters/)
+- [Docsy Hugo theme](https://www.docsy.dev/)
+- [Drupal Bootstrap 5 theme](https://www.drupal.org/project/bootstrap5)

--- a/development/020-frontend-ui-foundations.md
+++ b/development/020-frontend-ui-foundations.md
@@ -4,103 +4,96 @@
 
 ## Context
 
-WA Government digital services need consistent, accessible, maintainable web
-interfaces across public websites, portals, CMS templates, preview tools,
-widgets, and staff-facing applications. Teams often need to integrate with
-existing CMS platforms, third-party widgets, agency design systems, and
-independently delivered applications.
+WA Government digital services need accessible, consistent web interfaces
+across public sites, portals, CMS templates, preview tools, widgets, and staff
+applications. Teams also need UI patterns that work with agency design systems,
+third-party widgets, and independently delivered applications.
 
-Bespoke component systems can create avoidable maintenance burden, accessibility
-regressions, lock-in to a frontend framework, and integration problems for CMS
-or portal use cases. A mature, standards-based UI foundation helps teams build
-quickly while keeping semantic HTML, progressive enhancement, and WCAG 2.2 AA
-support visible.
-
-Bootstrap 5 is a mature, widely adopted frontend toolkit with documented layout,
-forms, components, helpers, utilities, and accessibility guidance. Its
-documentation notes that accessible outcomes still depend on correct author
-markup, styling, scripting, and colour choices. This makes Bootstrap a useful
-baseline, not a substitute for accessibility testing or design-system review.
+Bootstrap 5 is a mature frontend toolkit with documented layout, forms,
+components, helpers, utilities, and accessibility guidance. It gives teams a
+shared vocabulary for common web UI while still allowing agency design systems
+to theme, wrap, or extend components.
 
 ## Decision
 
-Prefer semantic HTML and Bootstrap 5-compatible component conventions for WA
-Government digital service web interfaces, unless an agency design system or
-product constraint requires a documented alternative.
+Use semantic HTML and Bootstrap 5-compatible component conventions as the
+default frontend foundation for WA Government digital service web interfaces.
 
-This does not require every service to import Bootstrap directly. A service may
-use an agency design system, theme, static-site template, web component, or
-framework-specific wrapper where it preserves Bootstrap-compatible structure,
-behaviour expectations, and accessibility semantics where practical.
-
-Frontend UI foundations must:
+This means teams should:
 
 - Start with semantic HTML, accessible names, keyboard support, and progressive
   enhancement
 - Meet WCAG 2.2 AA for user-facing interfaces
-- Prefer Bootstrap 5-compatible layout, form, navigation, alert, modal, table,
-  and utility conventions where a component is needed
-- Keep CSS and JavaScript scoped to avoid interfering with CMS editors,
-  third-party widgets, portal shells, embedded applications, and preview tools
-- Avoid bespoke component libraries unless there is a documented user,
-  accessibility, brand, or integration need
+- Use Bootstrap 5-compatible layout, forms, navigation, alerts, modals, tables,
+  cards, and utilities where common components are needed
+- Implement agency design systems as themes, wrappers, or extensions over this
+  baseline where practical
+- Scope CSS and JavaScript so shared components work safely in CMS templates,
+  portals, embedded apps, and third-party widget contexts
 - Keep design-system styling separate from business logic and service APIs
 
-## Implementation Guidance
+Teams may use another component library or native platform design system when
+it better fits the product. Record the reason in the project decision log.
 
-Use Bootstrap 5-compatible conventions as a baseline for:
+## Recommended Starting Points
 
-- CMS templates, static previews, and review tooling
-- Portal shells, account widgets, inbox widgets, and SDK-provided UI
-- Standalone staff tools, AI review companions, and administrative interfaces
-- Static sites, generated reports, and file-review outputs where HTML is used
+| Use case | Start with |
+|----------|------------|
+| Public site, CMS template, or static preview | Bootstrap 5-compatible theme and semantic HTML |
+| Technical documentation or review preview | Hugo with a Bootstrap-compatible theme such as Docsy |
+| CMS content preview or review pack | Hugo static build fed by file export, read-only feed, or content adapter |
+| Drupal-backed content platform | Drupal Bootstrap 5 theme or an agency theme aligned to Bootstrap 5 conventions |
+| Portal shell, account widget, inbox widget, or SDK UI | Small scoped Bootstrap-compatible components |
+| Staff tool or admin interface | Bootstrap-compatible forms, tables, alerts, and navigation |
 
-Agency design systems should wrap or theme the baseline rather than force each
-service to create incompatible components. Where a different frontend framework
-is used, keep generated HTML and interaction behaviour compatible with the
-documented design-system components where practical.
+## Hugo for Preview and Review Workflows
 
-For CMS and review workflows, prefer [Hugo](https://gohugo.io/) where a simple,
-reliable static site generator is enough. Hugo provides fast local builds,
-modular themes, and [content
-adapters](https://gohugo.io/content-management/content-adapters/) that can
-dynamically create pages from remote or file-based data sources such as JSON,
-TOML, YAML, or XML. This makes it practical to plug preview and review tools
-into existing content libraries without requiring deep CMS changes.
+Use [Hugo](https://gohugo.io/) when a simple, reliable static site generator is
+enough for previews, documentation, or review packs. Hugo works well for local
+builds, modular themes, and generated static outputs.
 
-[Docsy](https://www.docsy.dev/) is a useful reference implementation for Hugo
-technical documentation and preview sites. It is a Hugo theme designed for
-technical documentation and uses the Hugo module workflow. Use Docsy as a
-reference for modular Hugo site structure, not as a mandatory theme for all
-public services.
+Use [Hugo content
+adapters](https://gohugo.io/content-management/content-adapters/) to create
+pages from existing content libraries or read-only exports such as JSON, TOML,
+YAML, or XML. This lets teams build CMS-aligned previews without changing the
+CMS workflow first.
 
-For Drupal-backed content platforms, the contributed [Bootstrap 5
-theme](https://www.drupal.org/project/bootstrap5) is a useful reference for
-aligning Drupal theme work with Bootstrap 5 conventions. Drupal project pages
-may require browser JavaScript to view, so confirm module status, maintenance,
-and compatibility in the normal Drupal review process before adoption.
+[Docsy](https://www.docsy.dev/) is a useful Hugo reference theme for technical
+documentation and review sites. Use it as a starting point or comparison for
+modular Hugo structure, not as a mandatory theme.
 
-Do not use this ADR to override agency brand, accessibility, or content design
-requirements. Document deviations when another component library, framework,
-or native platform design system is a better fit.
+## Accessibility Expectations
+
+Bootstrap helps with accessible component patterns, but accessibility still
+depends on correct markup, content, colour choices, scripting, and testing.
+Projects must test the finished interface against WCAG 2.2 AA, including:
+
+- Keyboard operation and visible focus
+- Colour contrast and non-colour cues
+- Accessible names, labels, and error messages
+- Heading, landmark, table, and form structure
+- Reduced-motion behaviour where animation is used
+- Screen-reader behaviour for dynamic components such as modals, alerts, and
+  menus
 
 ## Consequences
 
 **Benefits:**
 
-- Reduces bespoke UI and component maintenance
-- Improves portability across CMS, portal, static preview, and standalone tool
-  contexts
+- Gives teams a clear default for common web UI
+- Improves portability across CMS, portal, preview, and standalone tool contexts
 - Supports accessible, semantic, progressively enhanced interfaces
-- Lowers integration risk with third-party widgets and independently owned apps
-- Gives teams a clear default without blocking agency-specific design systems
+- Reduces bespoke component maintenance
+- Keeps agency design systems compatible with a widely understood component
+  model
 
-**Risks if not implemented:**
+**Trade-offs:**
 
-- Inconsistent UI foundations across related services
-- Increased accessibility and regression testing burden
-- Harder CMS, portal, and widget integration
-- More bespoke frontend code to maintain and secure
+- Agency themes still need accessibility and brand review
+- Some products will need documented alternatives for native, highly bespoke, or
+  specialist user interfaces
+- Bootstrap-compatible conventions reduce variation but do not remove the need
+  for user research, content design, or usability testing
 
 ## Related Reference Architectures
 

--- a/glossary.md
+++ b/glossary.md
@@ -18,6 +18,7 @@
 **DKIM** - DomainKeys Identified Mail  
 **DMARC** - Domain-based Message Authentication, Reporting and Conformance  
 **DNS** - Domain Name System  
+**DSPF** - Digital Services Policy Framework (Western Australian Government)\
 **DTT** - Digital Transformation and Technology Unit  
 **EKS** - Elastic Kubernetes Service (AWS)  
 **ETL** - Extract, Transform, Load  

--- a/proposed-decision-backlog.md
+++ b/proposed-decision-backlog.md
@@ -15,11 +15,13 @@ item should move to `Accepted`, stay `Proposed`, or become `Superseded`.
 | [ADR 015: Data Governance](operations/015-data-governance.md) | Proposed | 2026-07-28 | Confirm ownership, classification, retention, and AI data-quality obligations |
 | [ADR 017: Analytics Tooling](operations/017-analytics-tooling.md) | Proposed | 2026-07-28 | Confirm Quarto use cases, publishing model, and dashboard boundaries |
 | [ADR 018: Database Patterns](operations/018-database-patterns.md) | Proposed | 2026-07-28 | Confirm managed database, lakehouse, and local development patterns |
+| [ADR 020: Frontend UI Foundations](development/020-frontend-ui-foundations.md) | Proposed | 2027-06-17 | Validate Bootstrap 5-compatible baseline, agency design-system fit, CMS and portal integration assumptions |
 
 ## Proposed Reference Architectures
 
 | Document | Current status | Next review | Review focus |
 |----------|----------------|-------------|--------------|
+| [AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md) | Proposed | 2027-06-17 | Validate Open Responses gateway, Bedrock Mantle backend, data minimisation, human accountability, and initial CMS authoring use case |
 | [Content Management](reference-architectures/content-management.md) | Proposed | 2026-07-28 | Validate CMS, CDN, WAF, editorial workflow, and media-storage assumptions |
 | [Data Pipelines](reference-architectures/data-pipelines.md) | Proposed | 2026-01-28 | Validate object-storage lakehouse, DuckDB/DuckLake, S3 Tables, and reporting flow |
 | [Federated Application Portal](reference-architectures/federated-application-portal.md) | Proposed | 2027-06-16 | Validate SDK scope, cross-organisation ownership, PWA support, mobile-webview handoff, and central service boundaries |

--- a/proposed-decision-backlog.md
+++ b/proposed-decision-backlog.md
@@ -21,7 +21,7 @@ item should move to `Accepted`, stay `Proposed`, or become `Superseded`.
 
 | Document | Current status | Next review | Review focus |
 |----------|----------------|-------------|--------------|
-| [AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md) | Proposed | 2027-06-17 | Validate Open Responses gateway, Bedrock Mantle backend, data minimisation, human accountability, and initial CMS authoring use case |
+| [AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md) | Proposed | 2027-06-17 | Validate Open Responses gateway, Bedrock Mantle backend, data minimisation, human accountability, and standalone review companion pattern |
 | [Content Management](reference-architectures/content-management.md) | Proposed | 2026-07-28 | Validate CMS, CDN, WAF, editorial workflow, and media-storage assumptions |
 | [Data Pipelines](reference-architectures/data-pipelines.md) | Proposed | 2026-01-28 | Validate object-storage lakehouse, DuckDB/DuckLake, S3 Tables, and reporting flow |
 | [Federated Application Portal](reference-architectures/federated-application-portal.md) | Proposed | 2027-06-16 | Validate SDK scope, cross-organisation ownership, PWA support, mobile-webview handoff, and central service boundaries |

--- a/reference-architectures/ai-assisted-digital-services.md
+++ b/reference-architectures/ai-assisted-digital-services.md
@@ -4,45 +4,39 @@
 
 ## When to Use This Pattern
 
-Use when adding low-risk AI assistance to a digital service, staff workflow,
-content process, portal, CMS, data product, or API-backed application.
+Use this pattern when adding low-risk AI assistance to a digital service, staff
+workflow, content process, portal, CMS, data product, or API-backed
+application.
 
-Start with this pattern when the team needs a simple companion tool for:
+Good first use cases:
 
 - Drafting, summarising, rewriting, and plain-English coaching
 - Content quality, accessibility, and policy checks before formal review
-- Staff productivity support over approved work documents
 - Explanations or summaries of curated reports and service information
-- Form-help, search-help, or service-officer assistance where humans remain
-  accountable
+- Form-help, search-help, or staff support where humans remain accountable
 
-Do not use this pattern for autonomous decisions, approvals, identity
-proofing, entitlement decisions, fraud decisions, publishing, payments,
-production changes, or actions that bypass human review.
+For high-impact decisions, publishing, payments, identity proofing,
+authorisation, fraud decisions, production changes, or agentic tool use, start
+with [ADR 011: AI Tool and Agent
+Governance](../security/011-ai-governance.md) and a separate risk assessment.
 
 ## Overview
 
-Build AI assistance as a **standalone review companion** first. The companion
-accepts a minimal content snapshot through copy/paste, file upload, static
-export, or a read-only preview feed. It returns suggestions, checks, preview
-pages, and review packs for humans to use in existing workflows.
+Start with a **standalone review companion**. It accepts a minimal content
+snapshot through copy/paste, file upload, static export, or read-only preview
+feed. It returns checks, suggestions, previews, and review packs for humans to
+use in existing workflows.
 
-Do not start by deeply embedding AI into CMS, portal, identity, or business
-workflow systems. Deep plugins and write-back integrations increase risk,
-coupling, and adoption cost. Add them only after the standalone workflow is
-proven and the owning system can support the integration safely.
+Keep the source system authoritative. Authors and reviewers apply accepted
+changes through the existing CMS, portal, document, or business workflow.
 
-The AI companion calls an internal gateway that implements an
-[Open Responses](https://www.openresponses.org/) compatible API. Applications
-and companion tools call the gateway, not model providers directly. The
-gateway enforces approved models, data minimisation, logging, prompt
-templates, token limits, and provider-specific privacy controls.
+Use an internal [Open Responses](https://www.openresponses.org/) compatible AI
+gateway for model access. The gateway owns provider configuration, model
+allow-lists, prompt templates, token limits, logging, and privacy settings.
 
 [Amazon Bedrock Mantle](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html)
-is the preferred initial backend where suitable because it exposes a
-Responses-style API through Amazon Bedrock and supports provider portability.
-Use an Australian region where available. Requests must set `store: false` by
-default so prompt and response content is not retained for conversation state.
+is the preferred initial backend where suitable. Use an Australian region where
+available and set `store: false` by default.
 
 ## Simple Architecture
 
@@ -50,128 +44,88 @@ default so prompt and response content is not retained for conversation state.
 flowchart LR
     source[CMS, document, report, or service content]
     snapshot[Minimal content snapshot]
-    companion[Standalone AI review companion]
+    companion[AI review companion]
     checks[Deterministic checks]
-    gateway[Internal Open Responses gateway]
+    gateway[Open Responses gateway]
     model[Bedrock Mantle or provider adapter]
-    outputs[Suggestions, preview, PDF/DOCX pack]
+    output[Suggestions, preview, review pack]
     workflow[Existing human workflow]
     logs[Audit and usage logs]
 
-    source -->|copy, upload, export, or read-only feed| snapshot
+    source -->|copy, upload, export, read-only feed| snapshot
     snapshot --> companion
     companion --> checks
     companion -->|minimal context| gateway
     gateway --> model
-    checks --> outputs
-    gateway --> outputs
-    outputs -->|human applies changes| workflow
+    checks --> output
+    gateway --> output
+    output -->|human applies accepted changes| workflow
     companion --> logs
     gateway --> logs
 ```
 
-The source system remains the system of record. The companion does not need
-privileged access and should not change workflow state. Humans copy accepted
-changes back, upload reviewed files, or use existing CMS and approval paths.
+## Delivery Levels
 
-## Roles and Responsibilities
+| Level | Build | Use for |
+|-------|-------|---------|
+| 0. Manual companion | Paste text or upload files | Fast proof of value with minimal integration |
+| 1. File-based review | Export Markdown, HTML, JSON, DOCX, CSV, or PDF snapshots | Repeatable checks, previews, and review evidence |
+| 2. Read-only feed | Consume a CMS preview feed, staging URL, report export, or minimal API | Safer integration with existing platforms |
+| 3. Inline assistance | Add selected-field UI integration | Proven workflows that justify deeper integration |
+| 4. Retrieval or tools | Add RAG, tools, or agentic workflows | Separately assessed use cases with stronger controls |
 
-| Party | Owns | Does not own |
-|-------|------|--------------|
-| Service, CMS, or app owner | Source content, business workflow, user context, final changes | Model credentials, provider selection, AI policy enforcement |
-| AI companion team | Review UI, deterministic checks, preview/export handling, user experience | Publishing, approvals, identity proofing, business decisions |
-| AI gateway team | Open Responses API, provider adapters, model allow-list, prompt policy, logging | Source-system workflow or content ownership |
-| Content or business reviewer | Standards, acceptance, approval, and official use of outputs | Treating AI output as automatically correct |
-| Security and privacy owners | Classification rules, provider approval, retention, monitoring requirements | Day-to-day drafting or editorial judgement |
+Start at level 0 or 1 unless the project has a clear operational reason to do
+more.
 
-## Integration Levels
-
-| Level | Team does | Use when |
-|-------|-----------|----------|
-| 0. Manual companion | Paste text or upload a file; no source-system integration | Proving value quickly with minimal risk |
-| 1. File-based review | Export Markdown, HTML, JSON, DOCX, or CSV snapshots; generate previews and review packs | The workflow needs repeatable review evidence |
-| 2. Read-only feed | Consume a CMS preview feed, staging URL, report export, or API with minimal fields | The source system can provide safe read-only access |
-| 3. Inline assistance | Add CMS, portal, or app UI integration for selected fields only | The standalone workflow is proven and integration risk is accepted |
-| 4. Tool use or RAG | Add retrieval, tools, or agentic workflows | Only after separate risk assessment and approval |
-
-Prefer levels 0-2 for the initial release. They are easier to secure, easier to
-replace, and less disruptive to existing content workflows.
-
-## Primary Journey: CMS Content Review
+## CMS Content Review Journey
 
 1. Author drafts content in the existing CMS or document workflow.
-2. Author exports, copies, uploads, or previews only the content section being
-   reviewed.
-3. The companion runs deterministic checks first: readability, headings,
-   links, required metadata, alt text presence, and obvious structure issues.
-4. The companion sends only the minimum selected context to the AI gateway.
-5. The gateway enforces model allow-list, region, prompt template, token
-   limits, `store: false`, and logging.
-6. The companion returns plain-English suggestions, likely WCAG 2.2 AA content
+2. Author copies, uploads, exports, or previews the section for review.
+3. Companion runs deterministic checks for readability, headings, links,
+   metadata, alt text presence, and structure.
+4. Companion sends only the minimum selected context to the AI gateway.
+5. Gateway applies model allow-list, region, prompt template, token limit,
+   `store: false`, and logging rules.
+6. Companion returns plain-English suggestions, likely WCAG 2.2 AA content
    issues, [Australian Government Style
    Manual](https://www.stylemanual.gov.au/) prompts, and structure
-   suggestions. This supports WA Government Digital Services Policy Framework
-   expectations for clear, accessible, user-centred public content.
-7. The companion renders a preview that matches the CMS design system where
-   practical.
-8. The companion can generate PDF or DOCX review packs for file-based sharing
-   and approval evidence.
-9. The author accepts, edits, or rejects suggestions.
-10. The author or reviewer applies accepted changes through the existing CMS or
-    document workflow. Existing approval and publishing controls remain
-    authoritative.
+   suggestions.
+7. Companion renders a CMS-aligned preview and optional PDF/DOCX review pack.
+8. Author accepts, edits, rejects, or applies suggestions through the existing
+   CMS workflow.
 
-## Reference Implementation Shape
+## Reference Implementation
 
-Start with a small web application or local/staff tool that can ingest content
-without privileged source-system access:
+Build a small web application or staff tool with:
 
-- Copy/paste text, selected HTML, Markdown, or structured fields
-- Upload DOCX, PDF, Markdown, HTML, CSV, or JSON where approved
-- Import a static CMS export or a read-only preview feed
-- Render a temporary preview site from the snapshot
-- Export suggestions, before/after text, check results, and reviewer notes
+- Copy/paste and file upload for text, HTML, Markdown, DOCX, PDF, CSV, or JSON
+- Optional import from static CMS export or read-only preview feed
+- Deterministic checks before model calls
+- Open Responses gateway client with `store: false` enforced server-side
+- Prompt template versioning and rollback
+- Preview site generation from the same checked snapshot
+- Exportable before/after suggestions, check results, reviewer notes, and
+  PDF/DOCX review packs
 
-For content platforms, prefer static site generation for preview and review
-environments. [Hugo](https://gohugo.io/) is a sensible default for simple,
-fast previews that can render the same information architecture, templates,
-and design-system components used by the CMS.
+Use [Hugo](https://gohugo.io/) for static preview and review sites where
+practical. Use [ADR 020: Frontend UI
+Foundations](../development/020-frontend-ui-foundations.md) for preview UI,
+semantic HTML, and Bootstrap 5-compatible component conventions.
 
-Follow [ADR 020: Frontend UI
-Foundations](../development/020-frontend-ui-foundations.md) for preview and
-review surfaces. Prefer Bootstrap 5-compatible semantic HTML and component
-conventions unless an agency design system or product constraint requires a
-documented alternative.
+## Gateway Requirements
 
-Generate PDF or DOCX review packs from the same file-based snapshot when
-reviewers need simple sharing, offline review, or approval evidence.
+The AI gateway should:
 
-## Provider Portability
-
-- Companion and application code must target the internal Open
-  Responses-compatible gateway, not Bedrock, OpenAI, Anthropic, or other
-  provider-specific APIs directly
-- Keep model IDs, backend URLs, regions, token limits, and provider features in
+- Expose an Open Responses-compatible API to companion and application clients
+- Keep model-provider credentials out of browsers, mobile apps, CMS plugins,
+  and portal widgets
+- Keep model IDs, backend URLs, regions, token limits, and provider options in
   server-side configuration
-- Run API compatibility or contract tests for gateway changes where practical
-- Keep browser, mobile, CMS, and portal clients free of model-provider
-  credentials
-- Support provider-specific extensions only behind the gateway and only when
-  the feature is justified for the use case
-
-## Bedrock Mantle Guidance
-
-When using Bedrock Mantle as the backend:
-
-- Use the Bedrock Mantle endpoint for the selected region, not a public OpenAI
-  endpoint
-- Prefer `ap-southeast-2` where the workload and selected model support it
-- Set `store: false` on every Responses API request unless a specific,
-  approved use case requires retained conversation state
-- Do not rely on provider-retained conversation history for official records;
-  keep required evidence in agency-controlled logs
-- Confirm model availability, quota, data residency, logging, and retention
-  assumptions before production use
+- Enforce `store: false` by default for Bedrock Mantle Responses API requests
+- Log model ID, prompt template/version, policy decisions, output summary, user
+  action, and accepted outputs
+- Apply per-route, per-user, token, rate, and cost limits
+- Validate request and response schemas in CI where practical
 
 Example gateway request shape:
 
@@ -188,92 +142,50 @@ Example gateway request shape:
 }
 ```
 
-## Data Minimisation and Safety Controls
+## Data Handling Rules
 
 - Send selected fields, paragraphs, snippets, or curated extracts rather than
-  full records or broad context
+  full records
 - Remove unnecessary personal information, identifiers, attachments, comments,
   and workflow metadata before model calls
-- Run deterministic checks first where rules are known, such as schema,
-  readability, heading structure, required metadata, or broken-link checks
-- Use prompt templates with versioning, review, and rollback
-- Apply route, user, token, and cost limits at the gateway
-- Fail closed when classification, provider, model, region, quota, or policy
-  checks are uncertain
-- Disable tool calls and source-system write-back by default
+- Keep source-system write-back, privileged actions, and tool calls disabled
+  until separately assessed
+- Keep required evidence in agency-controlled logs rather than relying on
+  provider-retained conversation state
+- Escalate when classification, provider, model, region, quota, or policy
+  checks are unclear
+
+## Roles and Responsibilities
+
+| Party | Owns |
+|-------|------|
+| Service, CMS, or app owner | Source content, user context, business workflow, final changes |
+| AI companion team | Review UI, deterministic checks, preview/export handling, user experience |
+| AI gateway team | Open Responses API, provider adapters, model allow-list, prompt policy, logging |
+| Content or business reviewer | Standards, acceptance, approval, and official use of outputs |
+| Security and privacy owners | Classification rules, provider approval, retention, and monitoring requirements |
 
 ## Cross-Reference Use Cases
 
 | Reference architecture | AI tie-in |
 |------------------------|-----------|
-| [Content Management](content-management.md) | Standalone content review companion, static preview, file review outputs, and compliance-left drafting checks |
+| [Content Management](content-management.md) | Content review companion, static preview, file review outputs, and compliance-left drafting checks |
 | [OpenAPI Backend](openapi-backends.md) | Internal Open Responses-compatible gateway and provider abstraction |
 | [Federated Application Portal](federated-application-portal.md) | Optional shared companion entry point through central services or SDK |
-| [Data Pipelines](data-pipelines.md) | Summaries and explanations over curated outputs only |
+| [Data Pipelines](data-pipelines.md) | Summaries and explanations over curated outputs |
 | [Identity Management](identity-management.md) | Authentication and authorisation boundary; no AI identity decisions |
-
-## What Good Looks Like
-
-- The first release works without CMS schema changes, privileged CMS access, or
-  publishing integration
-- Authors can use the companion with copied text, uploaded files, or exported
-  snapshots
-- Preview and review packs are generated from the same content snapshot that
-  was checked
-- Accepted changes are applied through existing human workflows
-- The gateway enforces approved providers, `store: false`, token limits,
-  logging, and prompt-template versions
-- The source system remains authoritative for workflow state, approval, and
-  publishing
-
-## Project Kickoff Steps
-
-1. **Pick the lowest integration level** - Start with manual or file-based
-   review before considering read-only feeds, inline plugins, tools, or RAG
-2. **Confirm AI governance** - Follow [ADR 011: AI Tool and Agent
-   Governance](../security/011-ai-governance.md) for approved tool use,
-   human accountability, model-provider assessment, and audit evidence
-3. **Define data boundaries** - Follow [ADR 015: Data Governance
-   Standards](../operations/015-data-governance.md) for ownership,
-   classification, retention, and minimum necessary disclosure
-4. **Design the gateway API** - Follow [OpenAPI Backend](openapi-backends.md)
-   and [ADR 003: API Documentation
-   Standards](../development/003-apis.md) for the internal gateway contract,
-   client schemas, validation, and compatibility tests
-5. **Apply isolation** - Follow [ADR 001: Application
-   Isolation](../security/001-isolation.md) for runtime, network, provider,
-   and administrative boundaries
-6. **Secure secrets and identity** - Follow [ADR 005: Secrets
-   Management](../security/005-secrets-management.md) for model-provider
-   credentials and [ADR 013: Identity Federation
-   Standards](../security/013-identity-federation.md) for authenticated user
-   access
-7. **Log evidence** - Follow [ADR 007: Centralised Security
-   Logging](../operations/007-logging.md) for prompts templates, model IDs,
-   policy decisions, user actions, denied actions, and accepted outputs
-8. **Release safely** - Follow [ADR 004: CI/CD Quality
-   Assurance](../development/004-cicd.md) and [ADR 009: Release
-   Standards](../development/009-release.md) for prompt, gateway, and client
-   changes
 
 ## Implementation Checklist
 
-- [ ] Initial release can operate as a standalone companion without privileged
-      source-system access
-- [ ] The chosen integration level and non-goals are documented
-- [ ] AI Accountable Officer, tool approval, and model-provider assessment are
-      documented
-- [ ] Application clients call only the internal Open Responses-compatible
-      gateway
-- [ ] Provider credentials, model IDs, regions, and retention settings are
-      controlled server-side
-- [ ] `store: false` or an approved retention exception is enforced by the
-      gateway
-- [ ] Data classification, minimisation, and prompt-template rules are tested
-- [ ] AI output cannot approve, publish, submit, delete, pay, authenticate,
-      authorise, or change workflow state
-- [ ] Logs record model ID, prompt template/version, policy decisions,
-      generated output summary, user action, and accepted outputs
+- [ ] Initial release level is selected and documented
+- [ ] AI Accountable Officer, tool approval, and provider assessment are recorded
+- [ ] Data classification and minimisation rules are implemented
+- [ ] Companion clients call only the internal Open Responses-compatible gateway
+- [ ] Provider credentials and provider options are controlled server-side
+- [ ] `store: false` is enforced by default for Bedrock Mantle requests
+- [ ] Deterministic checks run before model calls where rules are known
+- [ ] Logs capture model ID, prompt template/version, policy decisions, output
+      summary, user action, and accepted outputs
 - [ ] Human review, fallback behaviour, rate limits, and incident response are
       documented
 

--- a/reference-architectures/ai-assisted-digital-services.md
+++ b/reference-architectures/ai-assisted-digital-services.md
@@ -1,0 +1,291 @@
+# Reference Architecture: AI-Assisted Digital Services
+
+**Status:** Proposed | **Date:** 2026-06-17 | **Review:** 2027-06-17
+
+## When to Use This Pattern
+
+Use when adding low-risk AI assistance to a digital service, staff workflow,
+content process, portal, CMS, data product, or API-backed application.
+
+Start with this pattern when the team needs a simple companion tool for:
+
+- Drafting, summarising, rewriting, and plain-English coaching
+- Content quality, accessibility, and policy checks before formal review
+- Staff productivity support over approved work documents
+- Explanations or summaries of curated reports and service information
+- Form-help, search-help, or service-officer assistance where humans remain
+  accountable
+
+Do not use this pattern for autonomous decisions, approvals, identity
+proofing, entitlement decisions, fraud decisions, publishing, payments,
+production changes, or actions that bypass human review.
+
+## Overview
+
+Build AI assistance as a **standalone review companion** first. The companion
+accepts a minimal content snapshot through copy/paste, file upload, static
+export, or a read-only preview feed. It returns suggestions, checks, preview
+pages, and review packs for humans to use in existing workflows.
+
+Do not start by deeply embedding AI into CMS, portal, identity, or business
+workflow systems. Deep plugins and write-back integrations increase risk,
+coupling, and adoption cost. Add them only after the standalone workflow is
+proven and the owning system can support the integration safely.
+
+The AI companion calls an internal gateway that implements an
+[Open Responses](https://www.openresponses.org/) compatible API. Applications
+and companion tools call the gateway, not model providers directly. The
+gateway enforces approved models, data minimisation, logging, prompt
+templates, token limits, and provider-specific privacy controls.
+
+[Amazon Bedrock Mantle](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html)
+is the preferred initial backend where suitable because it exposes a
+Responses-style API through Amazon Bedrock and supports provider portability.
+Use an Australian region where available. Requests must set `store: false` by
+default so prompt and response content is not retained for conversation state.
+
+## Simple Architecture
+
+```mermaid
+flowchart LR
+    source[CMS, document, report, or service content]
+    snapshot[Minimal content snapshot]
+    companion[Standalone AI review companion]
+    checks[Deterministic checks]
+    gateway[Internal Open Responses gateway]
+    model[Bedrock Mantle or provider adapter]
+    outputs[Suggestions, preview, PDF/DOCX pack]
+    workflow[Existing human workflow]
+    logs[Audit and usage logs]
+
+    source -->|copy, upload, export, or read-only feed| snapshot
+    snapshot --> companion
+    companion --> checks
+    companion -->|minimal context| gateway
+    gateway --> model
+    checks --> outputs
+    gateway --> outputs
+    outputs -->|human applies changes| workflow
+    companion --> logs
+    gateway --> logs
+```
+
+The source system remains the system of record. The companion does not need
+privileged access and should not change workflow state. Humans copy accepted
+changes back, upload reviewed files, or use existing CMS and approval paths.
+
+## Roles and Responsibilities
+
+| Party | Owns | Does not own |
+|-------|------|--------------|
+| Service, CMS, or app owner | Source content, business workflow, user context, final changes | Model credentials, provider selection, AI policy enforcement |
+| AI companion team | Review UI, deterministic checks, preview/export handling, user experience | Publishing, approvals, identity proofing, business decisions |
+| AI gateway team | Open Responses API, provider adapters, model allow-list, prompt policy, logging | Source-system workflow or content ownership |
+| Content or business reviewer | Standards, acceptance, approval, and official use of outputs | Treating AI output as automatically correct |
+| Security and privacy owners | Classification rules, provider approval, retention, monitoring requirements | Day-to-day drafting or editorial judgement |
+
+## Integration Levels
+
+| Level | Team does | Use when |
+|-------|-----------|----------|
+| 0. Manual companion | Paste text or upload a file; no source-system integration | Proving value quickly with minimal risk |
+| 1. File-based review | Export Markdown, HTML, JSON, DOCX, or CSV snapshots; generate previews and review packs | The workflow needs repeatable review evidence |
+| 2. Read-only feed | Consume a CMS preview feed, staging URL, report export, or API with minimal fields | The source system can provide safe read-only access |
+| 3. Inline assistance | Add CMS, portal, or app UI integration for selected fields only | The standalone workflow is proven and integration risk is accepted |
+| 4. Tool use or RAG | Add retrieval, tools, or agentic workflows | Only after separate risk assessment and approval |
+
+Prefer levels 0-2 for the initial release. They are easier to secure, easier to
+replace, and less disruptive to existing content workflows.
+
+## Primary Journey: CMS Content Review
+
+1. Author drafts content in the existing CMS or document workflow.
+2. Author exports, copies, uploads, or previews only the content section being
+   reviewed.
+3. The companion runs deterministic checks first: readability, headings,
+   links, required metadata, alt text presence, and obvious structure issues.
+4. The companion sends only the minimum selected context to the AI gateway.
+5. The gateway enforces model allow-list, region, prompt template, token
+   limits, `store: false`, and logging.
+6. The companion returns plain-English suggestions, likely WCAG 2.2 AA content
+   issues, [Australian Government Style
+   Manual](https://www.stylemanual.gov.au/) prompts, and structure
+   suggestions. This supports WA Government Digital Services Policy Framework
+   expectations for clear, accessible, user-centred public content.
+7. The companion renders a preview that matches the CMS design system where
+   practical.
+8. The companion can generate PDF or DOCX review packs for file-based sharing
+   and approval evidence.
+9. The author accepts, edits, or rejects suggestions.
+10. The author or reviewer applies accepted changes through the existing CMS or
+    document workflow. Existing approval and publishing controls remain
+    authoritative.
+
+## Reference Implementation Shape
+
+Start with a small web application or local/staff tool that can ingest content
+without privileged source-system access:
+
+- Copy/paste text, selected HTML, Markdown, or structured fields
+- Upload DOCX, PDF, Markdown, HTML, CSV, or JSON where approved
+- Import a static CMS export or a read-only preview feed
+- Render a temporary preview site from the snapshot
+- Export suggestions, before/after text, check results, and reviewer notes
+
+For content platforms, prefer static site generation for preview and review
+environments. [Hugo](https://gohugo.io/) is a sensible default for simple,
+fast previews that can render the same information architecture, templates,
+and design-system components used by the CMS.
+
+Follow [ADR 020: Frontend UI
+Foundations](../development/020-frontend-ui-foundations.md) for preview and
+review surfaces. Prefer Bootstrap 5-compatible semantic HTML and component
+conventions unless an agency design system or product constraint requires a
+documented alternative.
+
+Generate PDF or DOCX review packs from the same file-based snapshot when
+reviewers need simple sharing, offline review, or approval evidence.
+
+## Provider Portability
+
+- Companion and application code must target the internal Open
+  Responses-compatible gateway, not Bedrock, OpenAI, Anthropic, or other
+  provider-specific APIs directly
+- Keep model IDs, backend URLs, regions, token limits, and provider features in
+  server-side configuration
+- Run API compatibility or contract tests for gateway changes where practical
+- Keep browser, mobile, CMS, and portal clients free of model-provider
+  credentials
+- Support provider-specific extensions only behind the gateway and only when
+  the feature is justified for the use case
+
+## Bedrock Mantle Guidance
+
+When using Bedrock Mantle as the backend:
+
+- Use the Bedrock Mantle endpoint for the selected region, not a public OpenAI
+  endpoint
+- Prefer `ap-southeast-2` where the workload and selected model support it
+- Set `store: false` on every Responses API request unless a specific,
+  approved use case requires retained conversation state
+- Do not rely on provider-retained conversation history for official records;
+  keep required evidence in agency-controlled logs
+- Confirm model availability, quota, data residency, logging, and retention
+  assumptions before production use
+
+Example gateway request shape:
+
+```json
+{
+  "model": "approved-model-id",
+  "input": [
+    {
+      "role": "user",
+      "content": "Rewrite this selected paragraph in plain English."
+    }
+  ],
+  "store": false
+}
+```
+
+## Data Minimisation and Safety Controls
+
+- Send selected fields, paragraphs, snippets, or curated extracts rather than
+  full records or broad context
+- Remove unnecessary personal information, identifiers, attachments, comments,
+  and workflow metadata before model calls
+- Run deterministic checks first where rules are known, such as schema,
+  readability, heading structure, required metadata, or broken-link checks
+- Use prompt templates with versioning, review, and rollback
+- Apply route, user, token, and cost limits at the gateway
+- Fail closed when classification, provider, model, region, quota, or policy
+  checks are uncertain
+- Disable tool calls and source-system write-back by default
+
+## Cross-Reference Use Cases
+
+| Reference architecture | AI tie-in |
+|------------------------|-----------|
+| [Content Management](content-management.md) | Standalone content review companion, static preview, file review outputs, and compliance-left drafting checks |
+| [OpenAPI Backend](openapi-backends.md) | Internal Open Responses-compatible gateway and provider abstraction |
+| [Federated Application Portal](federated-application-portal.md) | Optional shared companion entry point through central services or SDK |
+| [Data Pipelines](data-pipelines.md) | Summaries and explanations over curated outputs only |
+| [Identity Management](identity-management.md) | Authentication and authorisation boundary; no AI identity decisions |
+
+## What Good Looks Like
+
+- The first release works without CMS schema changes, privileged CMS access, or
+  publishing integration
+- Authors can use the companion with copied text, uploaded files, or exported
+  snapshots
+- Preview and review packs are generated from the same content snapshot that
+  was checked
+- Accepted changes are applied through existing human workflows
+- The gateway enforces approved providers, `store: false`, token limits,
+  logging, and prompt-template versions
+- The source system remains authoritative for workflow state, approval, and
+  publishing
+
+## Project Kickoff Steps
+
+1. **Pick the lowest integration level** - Start with manual or file-based
+   review before considering read-only feeds, inline plugins, tools, or RAG
+2. **Confirm AI governance** - Follow [ADR 011: AI Tool and Agent
+   Governance](../security/011-ai-governance.md) for approved tool use,
+   human accountability, model-provider assessment, and audit evidence
+3. **Define data boundaries** - Follow [ADR 015: Data Governance
+   Standards](../operations/015-data-governance.md) for ownership,
+   classification, retention, and minimum necessary disclosure
+4. **Design the gateway API** - Follow [OpenAPI Backend](openapi-backends.md)
+   and [ADR 003: API Documentation
+   Standards](../development/003-apis.md) for the internal gateway contract,
+   client schemas, validation, and compatibility tests
+5. **Apply isolation** - Follow [ADR 001: Application
+   Isolation](../security/001-isolation.md) for runtime, network, provider,
+   and administrative boundaries
+6. **Secure secrets and identity** - Follow [ADR 005: Secrets
+   Management](../security/005-secrets-management.md) for model-provider
+   credentials and [ADR 013: Identity Federation
+   Standards](../security/013-identity-federation.md) for authenticated user
+   access
+7. **Log evidence** - Follow [ADR 007: Centralised Security
+   Logging](../operations/007-logging.md) for prompts templates, model IDs,
+   policy decisions, user actions, denied actions, and accepted outputs
+8. **Release safely** - Follow [ADR 004: CI/CD Quality
+   Assurance](../development/004-cicd.md) and [ADR 009: Release
+   Standards](../development/009-release.md) for prompt, gateway, and client
+   changes
+
+## Implementation Checklist
+
+- [ ] Initial release can operate as a standalone companion without privileged
+      source-system access
+- [ ] The chosen integration level and non-goals are documented
+- [ ] AI Accountable Officer, tool approval, and model-provider assessment are
+      documented
+- [ ] Application clients call only the internal Open Responses-compatible
+      gateway
+- [ ] Provider credentials, model IDs, regions, and retention settings are
+      controlled server-side
+- [ ] `store: false` or an approved retention exception is enforced by the
+      gateway
+- [ ] Data classification, minimisation, and prompt-template rules are tested
+- [ ] AI output cannot approve, publish, submit, delete, pay, authenticate,
+      authorise, or change workflow state
+- [ ] Logs record model ID, prompt template/version, policy decisions,
+      generated output summary, user action, and accepted outputs
+- [ ] Human review, fallback behaviour, rate limits, and incident response are
+      documented
+
+## Related ADRs
+
+- [ADR 001: Application Isolation](../security/001-isolation.md)
+- [ADR 003: API Documentation Standards](../development/003-apis.md)
+- [ADR 004: CI/CD Quality Assurance](../development/004-cicd.md)
+- [ADR 005: Secrets Management](../security/005-secrets-management.md)
+- [ADR 007: Centralised Security Logging](../operations/007-logging.md)
+- [ADR 009: Release Standards](../development/009-release.md)
+- [ADR 011: AI Tool and Agent Governance](../security/011-ai-governance.md)
+- [ADR 013: Identity Federation Standards](../security/013-identity-federation.md)
+- [ADR 015: Data Governance Standards](../operations/015-data-governance.md)
+- [ADR 020: Frontend UI Foundations](../development/020-frontend-ui-foundations.md)

--- a/reference-architectures/content-management.md
+++ b/reference-architectures/content-management.md
@@ -76,6 +76,11 @@ flowchart LR
    Standards](../security/013-identity-federation.md) and [ADR 012:
    Privileged Remote Access](../security/012-privileged-remote-access.md)
    for editorial and administrative access
+6. **Optional AI Review Companion** - Follow [AI-Assisted Digital
+   Services](ai-assisted-digital-services.md) when adding standalone drafting,
+   readability, accessibility, or policy checks around the authoring experience
+7. **Configure Preview and Review Outputs** - Use a simple static preview and
+   file-export path where this reduces impact on existing CMS workflows
 
 ### Implementation Details
 
@@ -90,6 +95,42 @@ flowchart LR
   Standards](../development/003-apis.md) where content is consumed by
   other applications
 
+**Preview & Review Workflow:**
+
+- Use static site generation for preview and review environments where the CMS
+  can export draft content into files or a headless preview feed
+- Prefer [Hugo](https://gohugo.io/) for simple, fast previews that render the
+  same information architecture, templates, and design-system components used
+  by the CMS
+- Keep preview tooling aligned with the CMS design system but outside the core
+  authoring workflow where practical, so CMS upgrades, editorial permissions,
+  and third-party widgets are not tightly coupled to AI tooling
+- Follow [ADR 020: Frontend UI
+  Foundations](../development/020-frontend-ui-foundations.md) for CMS-facing
+  preview templates and review tooling. Prefer Bootstrap 5-compatible semantic
+  HTML and component conventions unless an agency design system or product
+  constraint requires a documented alternative.
+- Generate PDF or DOCX review packs from the same file-based content snapshot
+  when simple document sharing, offline review, or approval evidence is needed
+
+**Optional AI Review Companion:**
+
+- Use [AI-Assisted Digital Services](ai-assisted-digital-services.md) for
+  standalone drafting, readability, accessibility, and policy coaching
+- Prefer copy/paste, file upload, static export, or read-only preview feeds
+  before building CMS plugins or write-back integrations
+- Send only the selected paragraph, page section, metadata field, or exported
+  snapshot needed for the check
+- Run deterministic checks for readability, links, headings, alt text, and
+  required metadata before model calls
+- Return suggestions for authors to accept, edit, reject, or copy back through
+  the existing CMS workflow
+- Do not allow AI assistance to approve content, publish content, move workflow
+  state, bypass reviewer approval, or access privileged CMS administration APIs
+- Prefer standalone preview and file-output workflows for AI-assisted review
+  where this makes the tool usable across multiple CMS, staging, and local
+  environments
+
 **Media & Delivery:**
 
 - Store media assets in object storage as the source of truth
@@ -102,8 +143,13 @@ flowchart LR
 
 **Compliance & Quality:**
 
-- Test WCAG 2.1 AA accessibility before publishing templates or major
+- Test WCAG 2.2 AA accessibility before publishing templates or major
   content changes
+- Shift WA Government Digital Services Policy Framework expectations left into
+  the drafting process where practical, using the [Australian Government Style
+  Manual](https://www.stylemanual.gov.au/) as practical guidance for clear,
+  consistent, accessible, user-centred public content alongside WCAG 2.2 AA
+  checks
 - Apply content retention, disposal, and ownership rules per [ADR 015:
   Data Governance Standards](../operations/015-data-governance.md)
 - Configure privacy notices, cookie consent, and multilingual content

--- a/reference-architectures/data-pipelines.md
+++ b/reference-architectures/data-pipelines.md
@@ -91,6 +91,9 @@ flowchart LR
 3. **Publish Analytics** - Follow [ADR 017: Analytics Tooling
    Standards](../operations/017-analytics-tooling.md) for Quarto reports
    and dashboards
+4. **Optional AI Summaries** - Follow [AI-Assisted Digital
+   Services](ai-assisted-digital-services.md) when using AI to draft report
+   commentary, explain curated outputs, or summarise data-quality findings
 
 ## Implementation Details
 
@@ -111,6 +114,11 @@ flowchart LR
 - Run schema and sample-data checks in CI/CD
 - Track lineage through transformation code, table names, and release
   notes
+- Use AI only for summaries, explanations, report commentary, or data-quality
+  notes over curated and classified outputs. Do not give AI broad access to
+  raw datasets or lakehouse storage by default.
+- Prefer aggregated, minimised extracts for AI prompts and log AI-generated
+  report text for human review
 
 **Operations:**
 

--- a/reference-architectures/federated-application-portal.md
+++ b/reference-architectures/federated-application-portal.md
@@ -171,14 +171,20 @@ contracts, consent, and data minimisation.
    Standards](../development/004-cicd.md) and [ADR 009: Release
    Standards](../development/009-release.md) for SDK versioning,
    deprecation windows, compatibility matrices, and consumer test fixtures
-6. **Publish the app directory** - Define app icons, descriptions,
+6. **Apply frontend UI foundations** - Follow [ADR 020: Frontend UI
+   Foundations](../development/020-frontend-ui-foundations.md) for portal,
+   widget, SDK-provided UI, and shared service component conventions
+7. **Publish the app directory** - Define app icons, descriptions,
    eligibility rules, launch URLs, OIDC client mappings, and SSO behaviour
    before onboarding applications
-7. **Secure data, secrets, and logs** - Follow [ADR 005: Secrets
+8. **Secure data, secrets, and logs** - Follow [ADR 005: Secrets
    Management](../security/005-secrets-management.md), [ADR 007:
    Centralised Security Logging](../operations/007-logging.md), [ADR 015:
    Data Governance Standards](../operations/015-data-governance.md), and
    [ADR 018: Database Patterns](../operations/018-database-patterns.md)
+9. **Optional AI assistance** - Follow [AI-Assisted Digital
+   Services](ai-assisted-digital-services.md) when exposing shared AI
+   assistance through portal services, central APIs, or the SDK
 
 ## Implementation Notes
 
@@ -193,15 +199,24 @@ contracts, consent, and data minimisation.
   portal widget. Use widget dropdowns or focused overlays for account, inbox,
   notification, and consent actions instead of taking over the federated app
   page.
+- Prefer Bootstrap 5-compatible semantic HTML and component conventions for
+  portal, widget, and SDK-provided UI per [ADR 020: Frontend UI
+  Foundations](../development/020-frontend-ui-foundations.md). Keep shared UI
+  scoped so it does not interfere with independently owned applications.
 - Use PKCE-capable public-client flows. Do not require client secrets in
   browser or PWA code.
 - Participating apps decide when a business notification is needed. The
   central notification service owns delivery preferences, shared inbox
   display, delivery channels, and audit logging.
+- If AI assistance is provided, federated applications should call a central
+  Open Responses-compatible gateway rather than integrating directly with
+  model providers. App owners remain responsible for what context is sent.
+  The portal must not silently collect cross-app context for AI use.
 - Webview handoff must fail closed. Native bridge messages must be
   allow-listed, versioned, origin-bound, and auditable.
 - PWA and webview features must degrade safely when service workers, storage,
-  push notifications, native bridges, or deep links are unavailable
+  push notifications, native bridges, deep links, or AI services are
+  unavailable
 
 ## Implementation Checklist
 
@@ -231,3 +246,5 @@ contracts, consent, and data minimisation.
 - [ADR 015: Data Governance Standards](../operations/015-data-governance.md)
 - [ADR 016: Web Application Edge Protection](../security/016-edge-protection.md)
 - [ADR 018: Database Patterns](../operations/018-database-patterns.md)
+- [ADR 020: Frontend UI Foundations](../development/020-frontend-ui-foundations.md)
+- [AI-Assisted Digital Services](ai-assisted-digital-services.md)

--- a/reference-architectures/identity-management.md
+++ b/reference-architectures/identity-management.md
@@ -106,6 +106,12 @@ flowchart TB
 - Prohibit disclosure of identity information for marketing purposes
 - Ensure voluntary Digital ID participation where legislation requires it
 - Define breach notification and fraud incident response processes
+- Follow [AI-Assisted Digital Services](ai-assisted-digital-services.md) for
+  any AI support around identity operations. AI must not make authentication,
+  authorisation, identity proofing, entitlement, or fraud decisions.
+- Do not send identity attributes to models unless explicitly justified and
+  approved. Use minimal pseudonymous references where AI-assisted support or
+  audit analysis is required.
 
 **Assurance and Administration:**
 

--- a/reference-architectures/openapi-backends.md
+++ b/reference-architectures/openapi-backends.md
@@ -70,6 +70,9 @@ privileged users. Do not expose admin APIs directly to the Internet.
 6. **Logging & Monitoring** - Follow [ADR 007: Centralised Security
    Logging](../operations/007-logging.md) for user, system, and admin
    audit trails
+7. **AI Gateway APIs** - Follow [AI-Assisted Digital
+   Services](ai-assisted-digital-services.md) when building model access or
+   inference gateways for application clients
 
 ## Implementation Details
 
@@ -79,6 +82,19 @@ privileged users. Do not expose admin APIs directly to the Internet.
 - Version public routes with stable prefixes such as `/v1`
 - Use standard schema types and consistent error responses
 - Publish documentation from the same specification used for tests
+
+**AI Gateway APIs:**
+
+- Expose AI inference through an internal Open Responses-compatible gateway,
+  not provider-specific Bedrock, OpenAI, Anthropic, or other APIs
+- Keep model-provider credentials, model IDs, backend URLs, and retention
+  settings server-side
+- Separate normal inference APIs from privileged model, provider, prompt, and
+  policy administration APIs
+- Validate request and response schemas, rate limits, token limits, and
+  gateway compatibility in CI where practical
+- Enforce data minimisation and provider privacy controls such as `store:
+  false` at the gateway
 
 **Security Boundaries:**
 

--- a/review-schedule.md
+++ b/review-schedule.md
@@ -50,3 +50,5 @@ is completed.
 | 2027-06-09 | [Compliance Mapping](compliance-mapping.md) |
 | 2027-06-09 | [Glossary](glossary.md) |
 | 2027-06-16 | [Reference Architecture: Federated Application Portal](reference-architectures/federated-application-portal.md) |
+| 2027-06-17 | [ADR 020: Frontend UI Foundations](development/020-frontend-ui-foundations.md) |
+| 2027-06-17 | [Reference Architecture: AI-Assisted Digital Services](reference-architectures/ai-assisted-digital-services.md) |

--- a/security/011-ai-governance.md
+++ b/security/011-ai-governance.md
@@ -184,6 +184,14 @@ defaults, and reversible deployment. Tools with a similar posture to `oy`
 are preferred over broad agent platforms that add opaque orchestration,
 implicit trust, or unnecessary operational complexity.
 
+Service-facing AI integrations should follow [Reference Architecture:
+AI-Assisted Digital
+Services](../reference-architectures/ai-assisted-digital-services.md):
+applications call an internal Open Responses-compatible gateway, not model
+providers directly. The gateway should enforce data minimisation, approved
+models, logging, and provider privacy settings such as `store: false` where
+supported.
+
 `bedrock-mantle` is the preferred execution environment for this research
 where suitable because it enables access to open models through Amazon
 Bedrock and aligns with Mantle's zero operator access design, which AWS


### PR DESCRIPTION
## Purpose

Add two reusable guidance points for low-risk AI-assisted digital services:

1. AI assistance should start as a standalone review companion, not a deep CMS or workflow integration.
2. Frontend UI should default to semantic HTML and Bootstrap 5-compatible component conventions unless a documented agency/product constraint applies.

## Main decisions

- Add AI-Assisted Digital Services reference architecture.
- Add ADR 020: Frontend UI Foundations.
- Use an internal Open Responses-compatible AI gateway as the app-facing model API.
- Prefer Bedrock Mantle where suitable, with store: false by default.
- Keep source systems authoritative: no AI approval, publishing, workflow-state change, privileged CMS access, identity decision, or write-back by default.
- Prefer file/export/read-only preview workflows before plugins or inline integrations.
- Use Hugo/static previews and PDF/DOCX packs where useful for review evidence.

## SRE review focus

Please check:

- Are the trust boundaries clear enough to operate safely?
- Is the gateway/provider abstraction simple enough to support?
- Are logging, retention, and data-minimisation expectations explicit enough?
- Does the standalone companion approach avoid unnecessary CMS/platform coupling?
- Are the frontend defaults pragmatic for CMS, portal, preview, and widget contexts?

## Validation

- just build-ci passed.
- git diff --check passed.

Known existing issue: link check reports ISO 403s in identity docs; mdBook build completes.